### PR TITLE
ATO-157: Remove lambda signing config

### DIFF
--- a/stack-orchestration/configuration/build/build-rp-stub-pipeline/parameters.json
+++ b/stack-orchestration/configuration/build/build-rp-stub-pipeline/parameters.json
@@ -25,11 +25,11 @@
   },
   {
     "ParameterKey": "SigningProfileArn",
-    "ParameterValue": "arn:aws:signer:eu-west-2:616199614141:/signing-profiles/SigningProfile_82hlIhUN3wSY"
+    "ParameterValue": "none"
   },
   {
     "ParameterKey": "SigningProfileVersionArn",
-    "ParameterValue": "arn:aws:signer:eu-west-2:616199614141:/signing-profiles/SigningProfile_82hlIhUN3wSY/EFs2yWnYzD"
+    "ParameterValue": "none"
   },
   {
     "ParameterKey": "VpcStackName",

--- a/stack-orchestration/configuration/int/int-rp-stub-pipeline/parameters.json
+++ b/stack-orchestration/configuration/int/int-rp-stub-pipeline/parameters.json
@@ -25,11 +25,11 @@
   },
   {
     "ParameterKey": "SigningProfileArn",
-    "ParameterValue": "arn:aws:signer:eu-west-2:616199614141:/signing-profiles/SigningProfile_82hlIhUN3wSY"
+    "ParameterValue": "none"
   },
   {
     "ParameterKey": "SigningProfileVersionArn",
-    "ParameterValue": "arn:aws:signer:eu-west-2:616199614141:/signing-profiles/SigningProfile_82hlIhUN3wSY/EFs2yWnYzD"
+    "ParameterValue": "none"
   },
   {
     "ParameterKey": "VpcStackName",

--- a/stack-orchestration/configuration/prod/prod-rp-stub-pipeline/parameters.json
+++ b/stack-orchestration/configuration/prod/prod-rp-stub-pipeline/parameters.json
@@ -25,11 +25,11 @@
   },
   {
     "ParameterKey": "SigningProfileArn",
-    "ParameterValue": "arn:aws:signer:eu-west-2:616199614141:/signing-profiles/SigningProfile_82hlIhUN3wSY"
+    "ParameterValue": "none"
   },
   {
     "ParameterKey": "SigningProfileVersionArn",
-    "ParameterValue": "arn:aws:signer:eu-west-2:616199614141:/signing-profiles/SigningProfile_82hlIhUN3wSY/EFs2yWnYzD"
+    "ParameterValue": "none"
   },
   {
     "ParameterKey": "VpcStackName",

--- a/stack-orchestration/configuration/stage/stage-rp-stub-pipeline/parameters.json
+++ b/stack-orchestration/configuration/stage/stage-rp-stub-pipeline/parameters.json
@@ -29,11 +29,11 @@
   },
   {
     "ParameterKey": "SigningProfileArn",
-    "ParameterValue": "arn:aws:signer:eu-west-2:616199614141:/signing-profiles/SigningProfile_82hlIhUN3wSY"
+    "ParameterValue": "none"
   },
   {
     "ParameterKey": "SigningProfileVersionArn",
-    "ParameterValue": "arn:aws:signer:eu-west-2:616199614141:/signing-profiles/SigningProfile_82hlIhUN3wSY/EFs2yWnYzD"
+    "ParameterValue": "none"
   },
   {
     "ParameterKey": "VpcStackName",

--- a/template.yaml
+++ b/template.yaml
@@ -18,11 +18,6 @@ Parameters:
     Description: >
       The ARN of the permissions boundary to apply to any role created by the template
     Default: none
-  CodeSigningConfigArn:
-    Type: String
-    Description: >
-      The ARN of the Code Signing Config to use, provided by the deployment pipeline
-    Default: none
 
 Conditions:
   UsePermissionsBoundary:
@@ -30,21 +25,12 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - none
-  UseCodeSigning:
-    Fn::Not:
-      - Fn::Equals:
-          - !Ref CodeSigningConfigArn
-          - none
 
 Globals:
   Function:
     PermissionsBoundary: !If
       - UsePermissionsBoundary
       - !Ref PermissionsBoundary
-      - !Ref AWS::NoValue
-    CodeSigningConfigArn: !If
-      - UseCodeSigning
-      - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
 
 Mappings:


### PR DESCRIPTION
## What?

Remove lambda signing config
## Why?

We can't deploy signed lambda and ecr at the same time

