### PR TITLE
ATO-157: Add manual push to ecr and signing to deployment

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -15,18 +15,81 @@ jobs:
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SAM_APP_VALIDATE_ROLE_ARN: ${{ secrets.SAM_APP_VALIDATE_ROLE_ARN }}
-  deploy:
+  docker-build-and-push:
+    name: Docker build, push and deploy
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      AWS_REGION: eu-west-2
     permissions:
       id-token: write
       contents: read
     steps:
-      - name: Upload to ECR and tag
-        uses: govuk-one-login/devplatform-upload-action-ecr@1.2.0
+      - uses: actions/checkout@v2
         with:
-          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
-          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
-          working-directory: .
-          ecr-repo-name: ${{ secrets.ECR_REPOSITORY }}
+          fetch-depth: '0'
+
+      - name: Set up SAM cli
+        uses: aws-actions/setup-sam@v2
+
+      - name: Set up AWS creds
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Create tag
+        id: create-tag
+        run: |
+          IMAGE_TAG="${{ github.sha }}-rp-stub-$(date +'%Y-%m-%d-%H%M%S')"
+          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.9.0'
+
+      - name: Build, tag, sign and push image to Amazon ECR
+        env:
+          CONTAINER_SIGN_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
+        run: |
+          cd ${GITHUB_WORKSPACE} || exit 1
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          cosign sign --key awskms:///${CONTAINER_SIGN_KEY} $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: SAM Package
+        env:
+          ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
+        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=template.yaml
+
+      - name: Update SAM template with ECR image and broker login credentials
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ steps.create-tag.outputs.image_tag }}
+        run: |
+          sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG|" template.yaml
+
+      - name: SAM build and test
+        run: sam build -t template.yaml
+
+      - name: Deploy SAM app
+        uses: govuk-one-login/devplatform-upload-action@v3.3
+        with:
           artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
+          working-directory: .
+          template-file: template.yaml


### PR DESCRIPTION
## What?

Add manual push to ecr and signing of lambdas to deployment
## Why?

Dev platform have confirmed you cannot sign lambdas in the upload to ecr action: https://gds.slack.com/archives/C02U78Y5J3H/p1706700210012519?thread_ts=1706697999.762499&cid=C02U78Y5J3H
