### PR TITLE
ATO-157: Move lambda authorizer out of inline

### DIFF
--- a/authorizer/authorizer.js
+++ b/authorizer/authorizer.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const ip4ToInt = ip =>
+    ip.split('.').reduce((int, oct) => (int << 8) + parseInt(oct, 10), 0) >>> 0;
+
+const isIp4InCidr = ip => cidr => {
+    const [range, bits = 32] = cidr.split('/');
+    const mask = ~(2 ** (32 - bits) - 1);
+    return mask === 0
+        ? ip4ToInt(ip) === ip4ToInt(range)
+        : (ip4ToInt(ip) & mask) === (ip4ToInt(range) & mask);
+};
+
+const isIp4InCidrs = (ip, cidrs) => cidrs.some(isIp4InCidr(ip));
+
+exports.handler = async(event) => {
+    if (process.env.ENVIRONMENT === 'build') {
+        return {
+            'isAuthorized': true
+        };
+    }
+    const ipAddress = event.requestContext.http.sourceIp;
+    const validIps = [
+        '217.196.229.77/32',
+        '217.196.229.79/32',
+        '217.196.229.80/31',
+        '51.149.8.0/25',
+        '51.149.8.128/29',
+        '213.86.153.211/32',
+        '213.86.153.212/31',
+        '213.86.153.214/32',
+        '213.86.153.235/32',
+        '213.86.153.236/31',
+        '213.86.153.231/32'];
+    const isValidIp = isIp4InCidrs(ipAddress, validIps);
+    return {
+        'isAuthorized': isValidIp
+    };
+}

--- a/template.yaml
+++ b/template.yaml
@@ -728,53 +728,14 @@ Resources:
       # checkov:skip=CKV_AWS_116: DLQ not required
       # checkov:skip=CKV_AWS_117: Internet access not required
       ReservedConcurrentExecutions: 1
-      Handler: index.handler
+      Handler: authorizer.handler
       MemorySize: 128
       Runtime: nodejs20.x
       Timeout: 900
       Environment:
         Variables:
           ENVIRONMENT: !Ref Environment
-      InlineCode: |
-        'use strict';
-  
-        const ip4ToInt = ip =>
-          ip.split('.').reduce((int, oct) => (int << 8) + parseInt(oct, 10), 0) >>> 0;
-        
-        const isIp4InCidr = ip => cidr => {
-          const [range, bits = 32] = cidr.split('/');
-          const mask = ~(2 ** (32 - bits) - 1);
-          return mask === 0
-            ? ip4ToInt(ip) === ip4ToInt(range)
-            : (ip4ToInt(ip) & mask) === (ip4ToInt(range) & mask);
-        };
-        
-        const isIp4InCidrs = (ip, cidrs) => cidrs.some(isIp4InCidr(ip));
-        
-        exports.handler = async(event) => {
-          if (process.env.ENVIRONMENT === 'build') {
-            return {
-              'isAuthorized': true
-            };
-          }
-          const ipAddress = event.requestContext.http.sourceIp;
-          const validIps = [
-            '217.196.229.77/32',
-            '217.196.229.79/32',
-            '217.196.229.80/31',
-            '51.149.8.0/25',
-            '51.149.8.128/29',
-            '213.86.153.211/32',
-            '213.86.153.212/31',
-            '213.86.153.214/32',
-            '213.86.153.235/32',
-            '213.86.153.236/31',
-            '213.86.153.231/32'];
-            const isValidIp = isIp4InCidrs(ipAddress, validIps);
-            return {
-              'isAuthorized': isValidIp
-            };
-        };
+      CodeUri: authorizer
     Tags:
       - Key: Name
         Value: !Sub ${AWS::StackName}-ApiGatewayLambdaFunctionAuthorizer


### PR DESCRIPTION
## What?
Remove lambda authorizer code out of inline to separate file

## Why?

secure pipelines depends on the codeuri template property which inline code doesn't have

