### PR TITLE
ATO-154: Add IP addresses for performance test requests

### DIFF
--- a/authorizer/authorizer.js
+++ b/authorizer/authorizer.js
@@ -31,7 +31,10 @@ exports.handler = async(event) => {
         '213.86.153.214/32',
         '213.86.153.235/32',
         '213.86.153.236/31',
-        '213.86.153.231/32'];
+        '213.86.153.231/32',
+        '3.9.227.33/32',
+        '18.132.149.145/32',
+    ];
     const isValidIp = isIp4InCidrs(ipAddress, validIps);
     return {
         'isAuthorized': isValidIp


### PR DESCRIPTION
## What?

Add IP addresses in lambda authorizer for performance test requests
## Why?

So performance testers can use the stub for perf tests on the service
