### PR TITLE
ATO-158: Add build promotion allowed accounts

### DIFF
--- a/stack-orchestration/configuration/build/build-rp-stub-pipeline/parameters.json
+++ b/stack-orchestration/configuration/build/build-rp-stub-pipeline/parameters.json
@@ -1,5 +1,9 @@
 [
   {
+    "ParameterKey": "AllowedAccounts",
+    "ParameterValue": "388905755587"
+  },
+  {
     "ParameterKey": "ContainerSignerKmsKeyArn",
     "ParameterValue": "arn:aws:kms:eu-west-2:616199614141:key/d0d44be9-b8c2-4bff-b3d0-9c03b0273350"
   },


### PR DESCRIPTION
## What?

Add build promotion allowed account

## Why?

Needed for deployment to succeed

