### PR TITLE
ATO-204: Only export perf test in staging

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1435,6 +1435,9 @@ Outputs:
     Export:
       Name: !Sub DocAppApiGateway-${Environment}
   PerfTestApiId:
-    Value: !Ref PerfTestApiGateway
+    Value: !If
+      - IsStaging
+      - !Ref PerfTestApiGateway
+      - "no-value"
     Export:
       Name: !Sub PerfTestApiGateway-${Environment}


### PR DESCRIPTION
## What?

Only export the perf test API ID in staging

## Why?

It does not exist in other environments
