### PR TITLE
BAU: Set ID token in cookie instead of session

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -33,8 +33,7 @@ public class AuthCallbackHandler implements Route {
                 oidcClient.makeTokenRequest(
                         request.queryParams("code"), RelyingPartyConfig.authCallbackUrl());
         oidcClient.validateIdToken(tokens.getIDToken());
-        request.session().attribute("idToken", tokens.getIDToken().getParsedString());
-
+        response.cookie("/", "idToken", tokens.getIDToken().getParsedString(), 3600, false, true);
         var userInfo = oidcClient.makeUserInfoRequest(tokens.getAccessToken());
 
         var model = new HashMap<>();

--- a/src/main/java/uk/gov/di/handlers/HomeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/HomeHandler.java
@@ -16,8 +16,6 @@ public class HomeHandler implements Route {
 
     @Override
     public Object handle(Request request, Response response) {
-        request.session(true);
-
         var model = new HashMap<>();
         model.put("servicename", RelyingPartyConfig.serviceName());
         LOG.info(

--- a/src/main/java/uk/gov/di/handlers/SignOutHandler.java
+++ b/src/main/java/uk/gov/di/handlers/SignOutHandler.java
@@ -25,7 +25,7 @@ public class SignOutHandler implements Route {
         LOG.info("Generating log out request");
         var logoutUri =
                 oidcClient.buildLogoutUrl(
-                        request.session().attribute("idToken"),
+                        request.cookie("idToken"),
                         UUID.randomUUID().toString(),
                         RelyingPartyConfig.postLogoutRedirectUrl());
         response.redirect(logoutUri);


### PR DESCRIPTION
## What?

Set ID token in cookie instead of session

## Why?
Session is stored in memory, which is not shared across multiple servers. Ths does not work for performance testing, which has 6 instances
