### PR TITLE
ATO-362: Add wallet subject ID scope

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -46,6 +46,12 @@ public class AuthCallbackHandler implements Route {
             model.put("email", userInfo.getEmailAddress());
             model.put("phone_number", userInfo.getPhoneNumber());
 
+            var walletSubjectIDClaim =
+                    userInfo.getClaim("https://vocab.account.gov.uk/v1/walletSubjectID");
+            boolean walletSubjectIDClaimPresent = Objects.nonNull(walletSubjectIDClaim);
+            model.put("wallet_subject_id_claim_present", walletSubjectIDClaimPresent);
+            model.put("wallet_subject_id_claim", walletSubjectIDClaim);
+
             var coreIdentityJWT =
                     userInfo.getStringClaim("https://vocab.account.gov.uk/v1/coreIdentityJWT");
             boolean coreIdentityClaimPresent = Objects.nonNull(coreIdentityJWT);

--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -73,6 +73,11 @@ public class AuthorizeHandler implements Route {
                 scopes.add(formParameters.get("scopes-phone"));
             }
 
+            if (formParameters.containsKey("scopes-wallet-subject-id")) {
+                LOG.info("Wallet Subject ID scope requested");
+                scopes.add(formParameters.get("scopes-wallet-subject-id"));
+            }
+
             String vtr = formParameters.get("2fa");
 
             var prompt = formParameters.get("prompt");

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -80,6 +80,12 @@
                                     phone number
                                 </label>
                             </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="scopes-wallet-subject-id" name="scopes-wallet-subject-id" type="checkbox" value="wallet-subject-id">
+                                <label class="govuk-label govuk-checkboxes__label" for="scopes-wallet-subject-id">
+                                    wallet subject ID
+                                </label>
+                            </div>
                         </div>
                     </fieldset>
                 </div>

--- a/src/main/resources/templates/userinfo.mustache
+++ b/src/main/resources/templates/userinfo.mustache
@@ -161,6 +161,22 @@
                             {{return_code_claim}}
                         </dd>
                     </div>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      Wallet Subject ID Scope present
+                    </dt>
+                    <dd class="govuk-summary-list__value" id="user-info-wallet-subject-id-scope-present">
+                      {{wallet_subject_id_claim_present}}
+                    </dd>
+                  </div>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      Wallet subject ID Scope
+                    </dt>
+                    <dd class="govuk-summary-list__value" id="user-info-wallet-subject-id-scope">
+                      {{wallet_subject_id_claim}}
+                    </dd>
+                  </div>
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
                             ID Token


### PR DESCRIPTION
## What?

- Add checkbox to select wallet subject ID scope
- Display wallet subject ID on end userInfo page

## Why?

To be able to select the wallet subject ID scope

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/4003
