### PR TITLE
ATO-362: Update wallet-subject-id as now a scope not a claim

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -46,11 +46,10 @@ public class AuthCallbackHandler implements Route {
             model.put("email", userInfo.getEmailAddress());
             model.put("phone_number", userInfo.getPhoneNumber());
 
-            var walletSubjectIDClaim =
-                    userInfo.getClaim("https://vocab.account.gov.uk/v1/walletSubjectID");
-            boolean walletSubjectIDClaimPresent = Objects.nonNull(walletSubjectIDClaim);
-            model.put("wallet_subject_id_claim_present", walletSubjectIDClaimPresent);
-            model.put("wallet_subject_id_claim", walletSubjectIDClaim);
+            var walletSubjectID = userInfo.getClaim("wallet-subject-id");
+            boolean walletSubjectIDPresent = Objects.nonNull(walletSubjectID);
+            model.put("wallet_subject_id_present", walletSubjectIDPresent);
+            model.put("wallet_subject_id", walletSubjectID);
 
             var coreIdentityJWT =
                     userInfo.getStringClaim("https://vocab.account.gov.uk/v1/coreIdentityJWT");


### PR DESCRIPTION
## What?

Update wallet-subject-id value and remove mention of claim

## Why?

New format as a scope and removing "claim" should make it clearer that it isn't one of the valid claims

## Related PRs

https://github.com/govuk-one-login/relying-party-stub/pull/83
https://github.com/govuk-one-login/authentication-api/pull/4046
