### PR TITLE
ATO-NONE: Tidy up home page text

### DIFF
--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -124,7 +124,7 @@
                     <fieldset class="govuk-fieldset">
                         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                             <h3 class="govuk-fieldset__heading">
-                                Second factor auth
+                                Second factor authentication
                             </h3>
                         </legend>
                         <div class="govuk-radios">


### PR DESCRIPTION
## What?

Change 'auth' to 'authentication'
## Why?

For consistency on the landing page

