### PR TITLE
AUTH-2681 Adding Scaling policy for staging test client RP Stub

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -79,7 +79,10 @@ Mappings:
       docAppStubUrl: https://doc-app-rp-staging.build.stubs.account.gov.uk
       testClientDefaultClientId: nsR2wZ7EebJ2VOzE1LUa9iAVadunWQP3
       testClientStubUrl: https://perf-test-rp-staging.build.stubs.account.gov.uk
-      testClientInstances: 6
+      testClientInstances: 4
+      testClientInstancesmincount: 4
+      testClientInstancesmaxcount: 30
+      ALBPolicyTargetValue: 2000
       testClientCpu: 1024
       testClientMemory: 2048
     integration:
@@ -276,6 +279,62 @@ Resources:
         - Key: Owner
           Value: di-orchestration@digital.cabinet-office.gov.uk
     DependsOn: TestClientApplicationLoadBalancerListener
+
+  TestClientCSScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Condition: GenerateTestClient
+    Properties:
+      MaxCapacity: !FindInMap [ EnvironmentConfiguration, !Ref Environment, testClientInstancesmaxcount ]
+      MinCapacity: !FindInMap [ EnvironmentConfiguration, !Ref Environment, testClientInstancesmincount ]
+      ScalableDimension: "ecs:service:DesiredCount"
+      ServiceNamespace: "ecs"
+      ResourceId: !Join
+        - /
+        - - service
+          - !Ref FargateCluster
+          - !Ref TestClientContainerService
+      Tags:
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-TestClientContainerService
+        - Key: Service
+          Value: Relying Party Test Client stub
+        - Key: Source
+          Value: govuk-one-login/relying-party-stub
+        - Key: Owner
+          Value: di-orchestration@digital.cabinet-office.gov.uk
+
+  TestClientCSScalingPolicyCPU:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Condition: GenerateTestClient
+    Properties:
+      PolicyName: !Sub ${AWS::StackName}-target-tracking-cpu
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: Ref TestClientCSScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50.0
+        ScaleInCooldown: 240
+        ScaleOutCooldown: 60
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ECSServiceAverageCPUUtilization
+
+  TestClientCSScalingPolicyALB:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Condition: GenerateTestClient
+    Properties:
+      PolicyName: !Sub ${AWS::StackName}-alb-requests-per-target-per-minute
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: Ref TestClientCSScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: !FindInMap [ EnvironmentConfiguration, !Ref Environment, ALBPolicyTargetValue ]
+        ScaleInCooldown: 180
+        ScaleOutCooldown: 30
+        DisableScaleIn: true
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ALBRequestCountPerTarget
+          ResourceLabel: !Join 
+            - '/' 
+            - - !GetAtt TestClientApplicationLoadBalancer.LoadBalancerFullName
+              - !GetAtt TestClientApplicationLoadBalancerTargetGroup.TargetGroupFullName
 
   TestClientContainerServiceSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/template.yaml
+++ b/template.yaml
@@ -293,15 +293,6 @@ Resources:
         - - service
           - !Ref FargateCluster
           - !Ref TestClientContainerService
-      Tags:
-        - Key: Name
-          Value: !Sub ${AWS::StackName}-TestClientContainerService
-        - Key: Service
-          Value: Relying Party Test Client stub
-        - Key: Source
-          Value: govuk-one-login/relying-party-stub
-        - Key: Owner
-          Value: di-orchestration@digital.cabinet-office.gov.uk
 
   TestClientCSScalingPolicyCPU:
     Type: AWS::ApplicationAutoScaling::ScalingPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -70,6 +70,9 @@ Mappings:
       testClientDefaultClientId: Ykg9fGyY76On4e8tPvFabK5BIl65EkGH
       testClientStubUrl: https://acceptance-test-rp-build.build.stubs.account.gov.uk
       testClientInstances: 1
+      testClientInstancesmincount: 1
+      testClientInstancesmaxcount: 2
+      ALBPolicyTargetValue: 2000      
       testClientCpu: 256
       testClientMemory: 512
     staging:
@@ -888,6 +891,8 @@ Resources:
         HttpCode: 200
       TargetType: ip
       UnhealthyThresholdCount: 2
+      HealthyThresholdCount: 2
+      HealthCheckIntervalSeconds: 10
       VpcId:
         Fn::ImportValue: !Sub ${VpcStackName}-VpcId
       TargetGroupAttributes:


### PR DESCRIPTION
## What?

AUTH-2681 Adding Scaling policy for staging test client RP Stub

## Why?

We have a Perf Test which use staging test client RP stub , recent test shown that nos desired task are not enough to support the high volume test so adding a scaling policy to ECS task running Stubs to scale when CPU Utilisation is more than 50% or No of request Per Target is >2000

Also Adjusting the Target Health check value for test service  Heath check interval to 10 sec with 2 consecutive health check successes , so the target get ready and gets in service within 20 sec 
