### PR TITLE
lowering the desired Count for Staging RP

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -82,8 +82,8 @@ Mappings:
       docAppStubUrl: https://doc-app-rp-staging.build.stubs.account.gov.uk
       testClientDefaultClientId: nsR2wZ7EebJ2VOzE1LUa9iAVadunWQP3
       testClientStubUrl: https://perf-test-rp-staging.build.stubs.account.gov.uk
-      testClientInstances: 4
-      testClientInstancesmincount: 4
+      testClientInstances: 1
+      testClientInstancesmincount: 1
       testClientInstancesmaxcount: 30
       ALBPolicyTargetValue: 2000
       testClientCpu: 1024


### PR DESCRIPTION
## What?

lowering the desired Count for Staging RP

## Why?

Performance test are now running from performance RP created in Performance test Account so we don't need Staging RP to run 4 task  so lowering the count from 4 to 1 task however the scaling is in place if Traffic is on RP it will scale


