### PR TITLE
BAU:use the Relying Party from the URL parameters

### DIFF
--- a/src/main/java/uk/gov/di/handlers/HomeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/HomeHandler.java
@@ -16,8 +16,15 @@ public class HomeHandler implements Route {
 
     @Override
     public Object handle(Request request, Response response) {
-        var relyingPartyConfig =
-                Configuration.getRelyingPartyConfig(request.cookie("relyingParty"));
+        String relyingPartyString;
+        if (request.queryParams().contains("relyingParty")) {
+            relyingPartyString = request.queryParams("relyingParty");
+            response.cookie("/", "relyingParty", relyingPartyString, 3600, false, true);
+        } else {
+            relyingPartyString = request.cookie("relyingParty");
+        }
+
+        var relyingPartyConfig = Configuration.getRelyingPartyConfig(relyingPartyString);
         var model = new HashMap<>();
         model.put("servicename", relyingPartyConfig.serviceName());
         LOG.info(

--- a/src/test/java/uk/gov/di/handlers/HomeHandlerTest.java
+++ b/src/test/java/uk/gov/di/handlers/HomeHandlerTest.java
@@ -8,10 +8,13 @@ import uk.gov.di.config.Configuration;
 import uk.gov.di.config.RPConfig;
 import uk.gov.di.utils.ViewHelper;
 
+import java.util.HashSet;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class HomeHandlerTest {
@@ -35,6 +38,42 @@ class HomeHandlerTest {
             homeHandler.handle(mockRequest, mockResponse);
 
             viewHelperMock.verify(() -> ViewHelper.render(any(), eq("home.mustache")));
+        }
+    }
+
+    @Test
+    void shouldUseRpFromUrlParametersAndCreateCookie() {
+        try (MockedStatic<Configuration> configurationMockedStatic =
+                mockStatic(Configuration.class)) {
+            var relyingPartyConfigMock = mock(RPConfig.class);
+            configurationMockedStatic
+                    .when(() -> Configuration.getRelyingPartyConfig("testRpValue"))
+                    .thenReturn(relyingPartyConfigMock);
+            when(relyingPartyConfigMock.serviceName()).thenReturn("Test Service");
+            when(relyingPartyConfigMock.clientType()).thenReturn("web");
+
+            var mockRequest = mock(Request.class);
+            var mockResponse = mock(Response.class);
+
+            when(mockRequest.queryParams())
+                    .thenReturn(
+                            new HashSet<>() {
+                                {
+                                    add("relyingParty");
+                                }
+                            });
+            when(mockRequest.queryParams("relyingParty")).thenReturn("testRpValue");
+
+            homeHandler.handle(mockRequest, mockResponse);
+
+            verify(mockResponse)
+                    .cookie(
+                            eq("/"),
+                            eq("relyingParty"),
+                            eq("testRpValue"),
+                            eq(3600),
+                            eq(false),
+                            eq(true));
         }
     }
 }


### PR DESCRIPTION
If there is a value present for the relyingParty in the url query parameters, we want to use that and create a cookie automatically. This way, we don't need to go through the journey of changing the rp, we can just use a correct link

## What?

Use relyingParty from query parameters.

## Why?

This way we can provide a stub link in .env files (or other cases) that point us to the correct RP, without the need of going through the journey of setting it manually. 
This is needed to run acceptance tests locally.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
