### PR TITLE
BAU: Update the identity signing validation logic to use the DID for SPOT signing keys

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
             strictly '10.0.17'
         }
     }
+    implementation("decentralized-identity:did-common-java:1.11.0")
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.3',
             'org.mockito:mockito-inline:5.2.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.3'

--- a/config.json.template
+++ b/config.json.template
@@ -1,7 +1,7 @@
 {
   "T8qDL0betfsw1VKe03XnrPn79PyvnTbd" : {
     "client_private_key": "placeholder",
-    "identity_signing_public_key": null,
+    "identity_signing_key_url": "https://identity.staging.account.gov.uk/.well-known/did.json",
     "account_management_url": "https://home.build.account.gov.uk",
     "client_id": "T8qDL0betfsw1VKe03XnrPn79PyvnTbd",
     "client_type": "web",
@@ -13,7 +13,7 @@
   },
   "2kRDdPth7CLEXDfdO4xpFp2pJBQlxu3j": {
     "client_private_key": "placeholder",
-    "identity_signing_public_key": null,
+    "identity_signing_key_url": null,
     "account_management_url": "https://home.build.account.gov.uk",
     "client_id": "2kRDdPth7CLEXDfdO4xpFp2pJBQlxu3j",
     "client_type": "app",

--- a/src/main/java/uk/gov/di/config/RPConfig.java
+++ b/src/main/java/uk/gov/di/config/RPConfig.java
@@ -2,7 +2,7 @@ package uk.gov.di.config;
 
 public record RPConfig(
         String clientPrivateKey,
-        String identitySigningPublicKey,
+        String identitySigningKeyUrl,
         String accountManagementUrl,
         String clientId,
         String clientType,

--- a/src/main/java/uk/gov/di/utils/CoreIdentityValidator.java
+++ b/src/main/java/uk/gov/di/utils/CoreIdentityValidator.java
@@ -1,27 +1,28 @@
 package uk.gov.di.utils;
 
-import com.nimbusds.jose.Algorithm;
 import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
-import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
-import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jwt.SignedJWT;
+import foundation.identity.did.DIDDocument;
+import foundation.identity.did.VerificationMethod;
 import uk.gov.di.config.RPConfig;
 
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.interfaces.ECPublicKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.X509EncodedKeySpec;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
 import java.text.ParseException;
-import java.util.Base64;
+import java.util.HashMap;
 import java.util.Optional;
+
+import static java.net.http.HttpClient.newHttpClient;
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
 
 public class CoreIdentityValidator {
 
-    private final ECKey key;
+    private final URI didKeyUri;
+    private final HashMap<String, ECKey> keyCache = new HashMap<>();
 
     public enum Result {
         VALID,
@@ -30,40 +31,109 @@ public class CoreIdentityValidator {
     }
 
     public static CoreIdentityValidator createValidator(RPConfig relyingPartyConfig) {
-        return Optional.ofNullable(relyingPartyConfig.identitySigningPublicKey())
-                .map(Base64.getDecoder()::decode)
-                .map(X509EncodedKeySpec::new)
-                .flatMap(
-                        spec -> {
-                            try {
-                                return Optional.ofNullable(
-                                        KeyFactory.getInstance("EC").generatePublic(spec));
-                            } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-                                e.printStackTrace();
-                                return Optional.empty();
-                            }
-                        })
-                .map(ECPublicKey.class::cast)
-                .map(
-                        key ->
-                                new ECKey.Builder(Curve.P_256, key)
-                                        .keyUse(KeyUse.SIGNATURE)
-                                        .algorithm(new Algorithm(JWSAlgorithm.ES256.getName()))
-                                        .build())
+        return Optional.ofNullable(relyingPartyConfig.identitySigningKeyUrl())
                 .map(CoreIdentityValidator::new)
-                .orElse(new NoopCoreIdentityValidator());
+                .orElseGet(NoopCoreIdentityValidator::new);
     }
 
-    private CoreIdentityValidator(ECKey key) {
-        this.key = key;
+    private CoreIdentityValidator(String didKeyUrl) {
+        if (didKeyUrl != null) {
+            this.didKeyUri = URI.create(didKeyUrl);
+        } else {
+            this.didKeyUri = null;
+        }
     }
 
     public Result isValid(String jwt) {
         try {
-            return SignedJWT.parse(jwt).verify(new ECDSAVerifier(this.key))
+            var signedJWT = SignedJWT.parse(jwt);
+            var kid = getKeyID(signedJWT);
+            var key = getKeyById(kid);
+            return SignedJWT.parse(jwt).verify(new ECDSAVerifier(key))
                     ? Result.VALID
                     : Result.INVALID;
         } catch (JOSEException | ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String getKeyID(SignedJWT signedJWT) {
+        var kid = signedJWT.getHeader().getKeyID();
+        if (kid == null) {
+            throw new RuntimeException("No kid present in Core Identity");
+        }
+        return kid;
+    }
+
+    private ECKey getKeyById(String kid) {
+        return keyCache.computeIfAbsent(kid, this::fetchKeyFromDid);
+    }
+
+    private ECKey fetchKeyFromDid(String kid) {
+        var kidParts = kid.split("#");
+        var controller = kidParts[0];
+        var keyId = kidParts[1];
+        var did = DIDDocument.fromJson(fetchDidDocument());
+        var verificationMethod = getVerificationMethod(did, keyId);
+        verifyController(controller, verificationMethod);
+
+        return getEcKeyFromVerificationMethod(verificationMethod);
+    }
+
+    private static VerificationMethod getVerificationMethod(DIDDocument did, String keyId) {
+        var verificationMethodMaybe =
+                did.getAssertionMethodVerificationMethodsInline().stream()
+                        .filter(key -> keyId.equals(key.getId().toString()))
+                        .findFirst();
+
+        return verificationMethodMaybe.orElseThrow(
+                () -> new RuntimeException("No key found in DID with ID " + keyId));
+    }
+
+    private void verifyController(String controller, VerificationMethod verificationMethod) {
+        if (!controller.equals(verificationMethod.getController().toString())) {
+            throw new RuntimeException(
+                    "Controller in User Identity kid does not match DID key value: "
+                            + controller
+                            + " "
+                            + verificationMethod.getController().toString());
+        }
+        var expectedControllerFromHost = "did:web:" + didKeyUri.getHost();
+        if (!controller.equals(expectedControllerFromHost)) {
+            throw new RuntimeException(
+                    "Controller in User Identity kid does not match DID key URL: "
+                            + controller
+                            + " "
+                            + didKeyUri);
+        }
+    }
+
+    private static ECKey getEcKeyFromVerificationMethod(VerificationMethod verificationMethod) {
+        var publicJwkString = verificationMethod.getPublicKeyJwk();
+        try {
+            var publicJwk = JWK.parse(publicJwkString);
+            return publicJwk.toECKey();
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String fetchDidDocument() {
+        try {
+            HttpRequest request = HttpRequest.newBuilder(didKeyUri).build();
+            var response = newHttpClient().send(request, ofString());
+            if (response.statusCode() != 200) {
+                throw new RuntimeException(
+                        "DID document could not be fetched. Status code: "
+                                + response.statusCode()
+                                + " - "
+                                + response.body());
+            }
+            return response.body();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }

--- a/src/test/java/uk/gov/di/utils/CoreIdentityValidatorTest.java
+++ b/src/test/java/uk/gov/di/utils/CoreIdentityValidatorTest.java
@@ -1,0 +1,252 @@
+package uk.gov.di.utils;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import uk.gov.di.config.RPConfig;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class CoreIdentityValidatorTest {
+    private static ECKey SIGNING_KEY;
+    private static final String SIGNING_KEY_ID = "signing_key_kid";
+    private static final String CONTROLLER = "did:web:identity.test.account.gov.uk";
+    private static final String DID_URL =
+            "https://identity.test.account.gov.uk/.well-known/did.json";
+    private static CoreIdentityValidator underTest;
+    private static final HttpClient httpClient = mock(HttpClient.class);
+    private static MockedStatic<HttpClient> httpClientMockedStatic;
+
+    @BeforeAll
+    static void beforeAll() {
+        httpClientMockedStatic = mockStatic(HttpClient.class);
+        httpClientMockedStatic.when(HttpClient::newHttpClient).thenReturn(httpClient);
+    }
+
+    @BeforeEach
+    void setUp() throws JOSEException {
+        SIGNING_KEY =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyUse(KeyUse.SIGNATURE)
+                        .keyID(SIGNING_KEY_ID)
+                        .generate();
+
+        var rpConfig = mock(RPConfig.class);
+        when(rpConfig.identitySigningKeyUrl()).thenReturn(DID_URL);
+        underTest = CoreIdentityValidator.createValidator(rpConfig);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        httpClientMockedStatic.close();
+    }
+
+    @Test
+    void createValidatorReturnsNoopValidatorWhenDidUrlIsNull() {
+        // given
+        var rpConfig = mock(RPConfig.class);
+        when(rpConfig.identitySigningKeyUrl()).thenReturn(null);
+
+        // when
+        var validator = CoreIdentityValidator.createValidator(rpConfig);
+
+        // then
+        assertInstanceOf(CoreIdentityValidator.NoopCoreIdentityValidator.class, validator);
+    }
+
+    @Test
+    void noopValidatorReturnsNotValidated() {
+        // given
+        var rpConfig = mock(RPConfig.class);
+        when(rpConfig.identitySigningKeyUrl()).thenReturn(null);
+        var validator = CoreIdentityValidator.createValidator(rpConfig);
+
+        // when
+        var result = validator.isValid(createJws("kid"));
+
+        // then
+        assertEquals(CoreIdentityValidator.Result.NOT_VALIDATED, result);
+    }
+
+    @Test
+    void createValidatorReturnsValidatorWhenDidUrlIsPresent() {
+        // given
+        var rpConfig = mock(RPConfig.class);
+        when(rpConfig.identitySigningKeyUrl()).thenReturn("http://example.com");
+
+        // when
+        var validator = CoreIdentityValidator.createValidator(rpConfig);
+
+        // then
+        assertInstanceOf(CoreIdentityValidator.class, validator);
+    }
+
+    @Test
+    void succeedsWhenSignatureIsValid() {
+        configureDidDocumentResponse(SIGNING_KEY, CONTROLLER);
+        var result = underTest.isValid(createJws(CONTROLLER + "#" + SIGNING_KEY_ID));
+        assertEquals(CoreIdentityValidator.Result.VALID, result);
+    }
+
+    @Test
+    void failsWhenSignatureIsInvalid() throws JOSEException {
+        var didSigningKey =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyUse(KeyUse.SIGNATURE)
+                        .keyID(SIGNING_KEY_ID)
+                        .generate();
+        configureDidDocumentResponse(didSigningKey, CONTROLLER);
+        var result = underTest.isValid(createJws(CONTROLLER + "#" + SIGNING_KEY_ID));
+
+        assertEquals(CoreIdentityValidator.Result.INVALID, result);
+    }
+
+    @Test
+    void throwsExceptionWhenDidFetchErrors() throws IOException, InterruptedException {
+        var httpResponse = mock(HttpResponse.class);
+        when(httpResponse.statusCode()).thenReturn(400);
+        when(httpResponse.body()).thenReturn("Bad Request");
+        when(httpClient.send(any(), any())).thenReturn(httpResponse);
+
+        var thrownException =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> underTest.isValid(createJws("controller#id")));
+        assertEquals(
+                "DID document could not be fetched. Status code: 400 - Bad Request",
+                thrownException.getMessage());
+    }
+
+    @Test
+    void throwsExceptionIfKidNotPresentInJws() {
+        assertThrows(
+                RuntimeException.class,
+                () -> underTest.isValid(createJws(null)),
+                "No kid present in Core Identity");
+    }
+
+    @Test
+    void throwsExceptionWhenKidNotPresentInDidDocument() {
+        configureDidDocumentResponse(SIGNING_KEY, CONTROLLER);
+
+        var thrownException =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> underTest.isValid(createJws("controller#mismatched-kid")));
+        assertEquals("No key found in DID with ID mismatched-kid", thrownException.getMessage());
+    }
+
+    @Test
+    void throwsExceptionWhenKidControllerDoesNotMatchDidDocument() {
+        configureDidDocumentResponse(SIGNING_KEY, CONTROLLER);
+
+        var thrownException =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                underTest.isValid(
+                                        createJws("mismatched-controller#" + SIGNING_KEY_ID)));
+        assertEquals(
+                "Controller in User Identity kid does not match DID key value: mismatched-controller did:web:identity.test.account.gov.uk",
+                thrownException.getMessage());
+    }
+
+    @Test
+    void throwsExceptionWhenDidControllerDoesNotMatchDidEndpoint() {
+        String controller = "did:web:not-identity.test.account.gov.uk";
+        configureDidDocumentResponse(SIGNING_KEY, controller);
+
+        var thrownException =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> underTest.isValid(createJws(controller + "#" + SIGNING_KEY_ID)));
+        assertEquals(
+                "Controller in User Identity kid does not match DID key URL: did:web:not-identity.test.account.gov.uk https://identity.test.account.gov.uk/.well-known/did.json",
+                thrownException.getMessage());
+    }
+
+    private String createJws(String kid) {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder().subject("example").build();
+        try {
+            JWSSigner signer = new ECDSASigner(SIGNING_KEY);
+            JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(kid).build();
+            SignedJWT signedJwt = new SignedJWT(header, claims);
+            signedJwt.sign(signer);
+            return signedJwt.serialize();
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void configureDidDocumentResponse(ECKey ecKey, String controller) {
+        var assertion = buildDidAssertion(ecKey, controller);
+        var documentResponse = buildDidDocumentResponse(assertion, controller);
+        var httpResponse = mock(HttpResponse.class);
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn(documentResponse);
+        try {
+            when(httpClient.send(any(), any())).thenReturn(httpResponse);
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String buildDidAssertion(ECKey ecKey, String controller) {
+        var jwk = ecKey.toPublicJWK();
+        return String.format(
+                """
+                        {
+                              "id": "%s",
+                              "type": "JsonWebKey",
+                              "controller": "%s",
+                              "publicKeyJwk": {
+                                "kty": "EC",
+                                "crv": "P-256",
+                                "x": "%s",
+                                "y": "%s"
+                              }
+                            }
+                        """,
+                jwk.getKeyID(), controller, jwk.getX(), jwk.getY());
+    }
+
+    private String buildDidDocumentResponse(String assertionMethod, String controller) {
+        return String.format(
+                """
+                        {
+                          "@context": [
+                            "https://www.w3.org/ns/did/v1",
+                            "https://w3id.org/security/jwk/v1"
+                          ],
+                          "id": "%s",
+                          "assertionMethod": [
+                            %s
+                          ]
+                        }
+                        """,
+                controller, assertionMethod);
+    }
+}


### PR DESCRIPTION
SPOT are publishing their signing key(s) on a new endpoint in DID format. This change is to:

- Replace the public key in configuration with a URL to fetch keys from
- Update the Core Identity Validator to fetch the correct key and validate the signature using it
- Perform the validation suggested in the upcoming tech docs change (https://github.com/govuk-one-login/tech-docs/pull/200/files)
- Cache the fetched key indefinitely

In future, we should read and respect the cache control headers on the DID endpoint.

~~We have added a new dependency for this which is not published to maven central. It is limited to only the required packages, but if they add new dependencies we may need to allow more in the future.~~ This has been included in artifactory: https://github.com/govuk-one-login/artifactory-allowlist/pull/66
