### PR TITLE
Allow Auth dev account access to Dev RP stub

### DIFF
--- a/authorizer/authorizer.js
+++ b/authorizer/authorizer.js
@@ -37,6 +37,8 @@ exports.handler = async(event) => {
         '51.142.180.30/32',
         '185.120.72.241/32',
         '185.120.72.242/31',
+        //Below IP is public Ip of AWS Codebuild in eu-west-2 region
+        '35.176.92.32/29'  
     ];
     const isValidIp = isIp4InCidrs(ipAddress, validIps);
     return {


### PR DESCRIPTION
## What?

Allow Auth dev account access to Dev RP stub

## Why?

We are creating acceptance test to run in AUTH dev account on Dev RP stub so we need AWS codebuild London region public  IP  whit listed 


