### PR TITLE
ATO-692: JWKs endpoints for RP stub

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,8 @@ dependencies {
             'net.minidev:json-smart:2.5.1',
             "com.google.code.gson:gson:2.11.0",
             "software.amazon.awssdk:secretsmanager",
-            'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+            'com.fasterxml.jackson.core:jackson-databind:2.17.2',
+            "com.nimbusds:nimbus-jose-jwt:9.40"
     implementation('org.eclipse.jetty:jetty-server') {
         version {
             strictly '10.0.17'

--- a/src/main/java/uk/gov/di/config/Configuration.java
+++ b/src/main/java/uk/gov/di/config/Configuration.java
@@ -9,9 +9,12 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueReques
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Configuration extends HashMap<String, RPConfig> {
     private static final String LOCAL_CONFIGURATION_SOURCE = "local";
@@ -108,5 +111,9 @@ public class Configuration extends HashMap<String, RPConfig> {
 
     private static String defaultClientId() {
         return System.getenv().getOrDefault("DEFAULT_CLIENT_ID", null);
+    }
+
+    public static Stream<Map<String, Serializable>> getClientsPublicKeys() {
+        return getInstance().values().stream().map(RPConfig::jwksConfiguration);
     }
 }

--- a/src/main/java/uk/gov/di/config/RPConfig.java
+++ b/src/main/java/uk/gov/di/config/RPConfig.java
@@ -1,5 +1,10 @@
 package uk.gov.di.config;
 
+import uk.gov.di.utils.PrivateKeyReader;
+
+import java.io.Serializable;
+import java.util.Map;
+
 public record RPConfig(
         String clientPrivateKey,
         String identitySigningKeyUrl,
@@ -17,5 +22,13 @@ public record RPConfig(
 
     public String postLogoutRedirectUrl() {
         return Configuration.getStubUrl() + "/signed-out";
+    }
+
+    public Map<String, Serializable> jwksConfiguration() {
+        return Map.of(
+                "client_id",
+                clientId(),
+                "public_key",
+                new PrivateKeyReader(clientPrivateKey()).getPublicKey());
     }
 }

--- a/src/main/java/uk/gov/di/handlers/JwkHandler.java
+++ b/src/main/java/uk/gov/di/handlers/JwkHandler.java
@@ -1,0 +1,36 @@
+package uk.gov.di.handlers;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JwkHandler implements Route {
+    private final JWKSet jwkSet;
+
+    public JwkHandler(RSAPublicKey publicKey) {
+        var jwk = new RSAKey.Builder(publicKey).build();
+        List<JWK> keys = new ArrayList<>();
+        try {
+            keys.add(JWK.parse(jwk.toString()));
+            this.jwkSet = new JWKSet(keys);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Object handle(Request request, Response response) {
+
+        response.type("application/json");
+        response.header("Cache-Control", "max-age=86400");
+        return jwkSet.toJSONObject(true);
+    }
+}

--- a/src/main/java/uk/gov/di/utils/PrivateKeyReader.java
+++ b/src/main/java/uk/gov/di/utils/PrivateKeyReader.java
@@ -3,25 +3,44 @@ package uk.gov.di.utils;
 import java.io.IOException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
 import java.util.regex.Pattern;
 
 public class PrivateKeyReader {
     private String privateKey;
+    private KeyFactory kf;
 
     public PrivateKeyReader(String privateKey) {
-        this.privateKey = privateKey;
+        try {
+            this.privateKey = privateKey;
+            this.kf = KeyFactory.getInstance("RSA");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public RSAPrivateKey get() {
         try {
-            var kf = KeyFactory.getInstance("RSA");
             return (RSAPrivateKey)
                     kf.generatePrivate(new PKCS8EncodedKeySpec(format(this.privateKey)));
-        } catch (InvalidKeySpecException | IOException | NoSuchAlgorithmException e) {
+        } catch (InvalidKeySpecException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public RSAPublicKey getPublicKey() {
+        try {
+            var privateKey = (RSAPrivateCrtKey) get();
+            RSAPublicKeySpec publicKeySpec =
+                    new RSAPublicKeySpec(privateKey.getModulus(), privateKey.getPublicExponent());
+            return (RSAPublicKey) kf.generatePublic(publicKeySpec);
+        } catch (InvalidKeySpecException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/test/java/uk/gov/di/handlers/JwkHandlerTest.java
+++ b/src/test/java/uk/gov/di/handlers/JwkHandlerTest.java
@@ -1,0 +1,50 @@
+package uk.gov.di.handlers;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import spark.Request;
+import spark.Response;
+
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static uk.gov.di.helpers.keyHelper.generateRsaKeyPair;
+
+public class JwkHandlerTest {
+    private final RSAPublicKey TEST_PUBLIC_KEY = (RSAPublicKey) generateRsaKeyPair().getPublic();
+    private JwkHandler jwkHandler;
+
+    @BeforeEach
+    void globalSetup() {
+        jwkHandler = new JwkHandler(TEST_PUBLIC_KEY);
+    }
+
+    @Test
+    void shouldReturnAJwkResponse() throws ParseException {
+
+        var mockRequest = mock(Request.class);
+        var mockResponse = mock(Response.class);
+        var response = jwkHandler.handle(mockRequest, mockResponse);
+        verify(mockResponse).header(eq("Cache-Control"), eq("max-age=86400"));
+        verify(mockResponse).type("application/json");
+        assertEquals(expectedJWK(TEST_PUBLIC_KEY), response);
+    }
+
+    private Map<String, Object> expectedJWK(RSAPublicKey publicKey) throws ParseException {
+        var jwk = new RSAKey.Builder(publicKey).build();
+        List<JWK> keys = new ArrayList<>();
+        keys.add(JWK.parse(jwk.toString()));
+        JWKSet jwkSet = new JWKSet(keys);
+        return jwkSet.toJSONObject(true);
+    }
+}

--- a/src/test/java/uk/gov/di/helpers/keyHelper.java
+++ b/src/test/java/uk/gov/di/helpers/keyHelper.java
@@ -1,0 +1,18 @@
+package uk.gov.di.helpers;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+
+public class keyHelper {
+    public static KeyPair generateRsaKeyPair() {
+        KeyPairGenerator kpg;
+        try {
+            kpg = KeyPairGenerator.getInstance("RSA");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        kpg.initialize(2048);
+        return kpg.generateKeyPair();
+    }
+}

--- a/src/test/java/uk/gov/di/utils/PrivateKeyReaderTest.java
+++ b/src/test/java/uk/gov/di/utils/PrivateKeyReaderTest.java
@@ -1,0 +1,32 @@
+package uk.gov.di.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPair;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.helpers.keyHelper.generateRsaKeyPair;
+
+public class PrivateKeyReaderTest {
+    private final KeyPair TEST_RSA_KEY_PAIR = generateRsaKeyPair();
+    private final RSAPrivateKey testPrivateKey = (RSAPrivateKey) TEST_RSA_KEY_PAIR.getPrivate();
+    private final String serializedPrivateKey =
+            Base64.getMimeEncoder().encodeToString(testPrivateKey.getEncoded());
+    private final RSAPublicKey publicKey = (RSAPublicKey) TEST_RSA_KEY_PAIR.getPublic();
+    private final PrivateKeyReader privateKeyReader = new PrivateKeyReader(serializedPrivateKey);
+
+    @Test
+    void shouldParsePrivateKeyFromString() {
+        var receivedPrivateKey = privateKeyReader.get();
+        assertEquals(receivedPrivateKey, testPrivateKey);
+    }
+
+    @Test
+    void shouldReturnPublicKeyFromPrivate() {
+        var receivedPublicKey = privateKeyReader.getPublicKey();
+        assertEquals(receivedPublicKey, publicKey);
+    }
+}


### PR DESCRIPTION
## What?

Please include a summary of the change.
- Adds new routes for each stub RP in the format `/:clientId/.well-known/jwks.json` publishing their public key.
- These routes dynamically generate for each RP provided in the config
- Adds a new JWK handler and relevant dependencies 

## Why?

Please include reason for the change and any other relevant context.
- This allows us to test fetching an RP public key from a JWKs endpoint. 

## Review Notes:
- Code review commit-by-commit

