### PR TITLE
BAU: add account management to stub scopes

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -96,6 +96,11 @@ public class AuthorizeHandler implements Route {
                 scopes.add(formParameters.get("scopes-wallet-subject-id"));
             }
 
+            if (formParameters.containsKey("scopes-account-management")) {
+                LOG.info("Account Management scope requested");
+                scopes.add(formParameters.get("scopes-account-management"));
+            }
+
             String vtr = formParameters.get("2fa");
 
             var prompt = formParameters.get("prompt");

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -98,6 +98,12 @@
                                     wallet subject ID
                                 </label>
                             </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="scopes-account-management" name="scopes-account-management" type="checkbox" value="am">
+                                <label class="govuk-label govuk-checkboxes__label" for="scopes-account-management">
+                                    Account Management
+                                </label>
+                            </div>
                         </div>
                     </fieldset>
                 </div>


### PR DESCRIPTION
## What?

Add account management to stub scopes

## Why?

By adding the AM to the list of scopes, we can obtain a bearer token (at the end of a journey which logs the user in) which contains "am" in the scopes claim. This is needed for acceptance tests for account management.

