### PR TITLE
BAU: Alter kid to DID key ID matching

### DIFF
--- a/src/main/java/uk/gov/di/utils/CoreIdentityValidator.java
+++ b/src/main/java/uk/gov/di/utils/CoreIdentityValidator.java
@@ -72,9 +72,8 @@ public class CoreIdentityValidator {
     private ECKey fetchKeyFromDid(String kid) {
         var kidParts = kid.split("#");
         var controller = kidParts[0];
-        var keyId = kidParts[1];
         var did = DIDDocument.fromJson(fetchDidDocument());
-        var verificationMethod = getVerificationMethod(did, keyId);
+        var verificationMethod = getVerificationMethod(did, kid);
         verifyController(controller, verificationMethod);
 
         return getEcKeyFromVerificationMethod(verificationMethod);


### PR DESCRIPTION
## What?

- We should match the entire `kid` to the `id` of the verification method in the DID document.

## Why?

The format of the DID document has recently changed, see PR https://github.com/govuk-one-login/tech-docs/pull/238

## Related PRs

https://github.com/govuk-one-login/tech-docs/pull/238
