### PR TITLE
BAU: add unique id to user info access token

### DIFF
--- a/src/main/resources/templates/userinfo.mustache
+++ b/src/main/resources/templates/userinfo.mustache
@@ -197,7 +197,7 @@
                         <dt class="govuk-summary-list__key">
                             Access Token
                         </dt>
-                        <dd class="govuk-summary-list__value" id="user-info-id-token">
+                        <dd class="govuk-summary-list__value" id="user-info-access-token">
                             {{access_token}}
                         </dd>
                     </div>


### PR DESCRIPTION
## What?

Add unique id to user info access token

## Why?

The same id is used for different elements with different scopes. This adds an unique id for the access (bearer) token
