### PR TITLE
BAU: Rewrite dependency constraint to ensure jetty stays on latest patch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,11 @@ ext {
 }
 
 dependencies {
+    constraints {
+        implementation("org.eclipse.jetty:jetty-server:[10.0.23,11)")
+        implementation("org.eclipse.jetty:jetty-webapp:[10.0.23,11)")
+    }
+
     implementation(platform("software.amazon.awssdk:bom:2.27.17"))
     implementation "com.sparkjava:spark-core:2.9.4",
             "com.sparkjava:spark-template-mustache:2.7.1",
@@ -43,11 +48,6 @@ dependencies {
             "software.amazon.awssdk:secretsmanager",
             'com.fasterxml.jackson.core:jackson-databind:2.17.2',
             "com.nimbusds:nimbus-jose-jwt:9.40"
-    implementation('org.eclipse.jetty:jetty-server') {
-        version {
-            strictly '10.0.17'
-        }
-    }
     implementation("decentralized-identity:did-common-java:1.13.0")
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.0',
             'org.mockito:mockito-inline:5.2.0'


### PR DESCRIPTION
This will also fix the security advisory
