### PR TITLE
BAU: Add expiry to DID caching

### DIFF
--- a/src/test/java/uk/gov/di/helpers/TestClock.java
+++ b/src/test/java/uk/gov/di/helpers/TestClock.java
@@ -1,0 +1,37 @@
+package uk.gov.di.helpers;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class TestClock extends Clock {
+    private Instant instant;
+    private final ZoneId zone;
+
+    public TestClock(Instant instant, ZoneId zoneId) {
+        this.instant = instant;
+        this.zone = zoneId;
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return zone;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        if (zone.equals(this.zone)) { // intentional NPE
+            return this;
+        }
+        return new TestClock(instant, zone);
+    }
+
+    @Override
+    public Instant instant() {
+        return this.instant;
+    }
+
+    public void setInstant(Instant instant) {
+        this.instant = instant;
+    }
+}


### PR DESCRIPTION

## What?

Limit the time core identity signing keys are cached for to respect the max-age parameter in the cache control header

## Why?
Without cache expiry, key revocation does not work. This is not a particular issue for the stub, but this code is being used as reference by RPs.

