### PR TITLE
BAU: Remove auth team as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/auth-team @govuk-one-login/auth-leads @govuk-one-login/orchestration-leads @govuk-one-login/orchestration-team
+* @govuk-one-login/orchestration-leads @govuk-one-login/orchestration-team


### PR DESCRIPTION
Orchestration own this repo. So in the spirit of the auth/orch split, removing auth as an owner of this repo.