### PR TITLE
ATO-1329: Fix claim format in request object

### DIFF
--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -201,6 +201,8 @@ public class Oidc {
             throw new RuntimeException("Unable to parse prompt", e);
         }
 
+        var userInfoClaimsRequest =
+                new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
         var requestObject =
                 new JWTClaimsSet.Builder()
                         .audience(this.providerMetadata.getAuthorizationEndpointURI().toString())
@@ -211,7 +213,7 @@ public class Oidc {
                         .claim("client_id", this.clientId.getValue())
                         .claim("state", new State().getValue())
                         .claim("vtr", jsonArray)
-                        .claim("claims", claimsSetRequest.toJSONString())
+                        .claim("claims", userInfoClaimsRequest.toJSONString())
                         .claim("prompt", authRequestPrompt.toString())
                         .issuer(this.clientId.getValue());
 

--- a/src/test/java/uk/gov/di/utils/OidcTest.java
+++ b/src/test/java/uk/gov/di/utils/OidcTest.java
@@ -1,0 +1,66 @@
+package uk.gov.di.utils;
+
+import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
+import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.config.RPConfig;
+
+import java.security.KeyPair;
+import java.security.interfaces.RSAPrivateKey;
+import java.text.ParseException;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.helpers.keyHelper.generateRsaKeyPair;
+
+public class OidcTest {
+    private RPConfig rpConfig = mock(RPConfig.class);
+    private final KeyPair TEST_RSA_KEY_PAIR = generateRsaKeyPair();
+    private final RSAPrivateKey testPrivateKey = (RSAPrivateKey) TEST_RSA_KEY_PAIR.getPrivate();
+    private final String serializedPrivateKey =
+            Base64.getMimeEncoder().encodeToString(testPrivateKey.getEncoded());
+    private final String testClientId = "aClient";
+    private final String testCallbackUri = "https://example.com/authentication-callback";
+    private final String testVtr = "[\"Cl.Cm\"]";
+    private final List<String> testScopes = List.of("openid", "phone");
+    private final ClaimsSetRequest testClaimSetRequest =
+            new ClaimsSetRequest()
+                    .add(new ClaimsSetRequest.Entry("https://vocab.example.com/v1/permit"));
+    private Oidc oidc;
+
+    @BeforeEach
+    void setup() {
+        when(rpConfig.clientPrivateKey()).thenReturn(serializedPrivateKey);
+        when(rpConfig.clientId()).thenReturn(testClientId);
+        when(rpConfig.jwksConfiguration()).thenReturn(Map.of("public_key_id", "12345"));
+        when(rpConfig.opBaseUrl()).thenReturn("https://oidc.sandpit.account.gov.uk/");
+        oidc = new Oidc(rpConfig);
+    }
+
+    @Test
+    void shouldCreateJARWithExpectedUserInfoClaims() throws ParseException {
+        var authorizeRequest =
+                oidc.buildJarAuthorizeRequest(
+                        testCallbackUri,
+                        testVtr,
+                        testScopes,
+                        testClaimSetRequest,
+                        "en",
+                        "login",
+                        "",
+                        "",
+                        "123");
+
+        var jarClaims = authorizeRequest.getRequestObject().getJWTClaimsSet();
+        var expectedClaims = new OIDCClaimsRequest().withUserInfoClaimsRequest(testClaimSetRequest);
+        assertEquals(expectedClaims.toJSONString(), jarClaims.getStringClaim("claims"));
+        assertNull(jarClaims.getClaim("id_token_hint"));
+        assertNull(jarClaims.getClaim("rp_sid"));
+    }
+}


### PR DESCRIPTION
## What?:

Fixes the formatting of claims in the request object so that they are specified as `userinfo` claims and not just top level JSON keys

## Why?

As part of other work[1], we're adding validation to the claims included in request objects. This requires us to put the claims nested under the 'userinfo' property which the code is not currently doing. This corrects that by attatching the claims as userinfo claims when making a request object authorize JAR

[1]- https://github.com/govuk-one-login/authentication-api/pull/5721
## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
