### PR TITLE
BAU: Pin jetty-http due to CVE-2024-6763

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
         implementation("org.eclipse.jetty:jetty-server:[10.0.23,11)")
         implementation("org.eclipse.jetty:jetty-webapp:[10.0.23,11)")
         implementation("io.netty:netty-common:[4.1.115.Final,4.2)")
+        implementation("org.eclipse.jetty:jetty-http:[12.0.12,12.1)")
     }
 
     implementation(platform("software.amazon.awssdk:bom:2.28.19"))


### PR DESCRIPTION
## What?

Please include a summary of the change.

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
