### PR TITLE
ATO-1411: Remove social security claim from stub

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -77,14 +77,9 @@ public class AuthCallbackHandler implements Route {
             boolean drivingPermitClaimPresent =
                     Objects.nonNull(
                             userInfo.getClaim("https://vocab.account.gov.uk/v1/drivingPermit"));
-            boolean socialSecurityRecordClaimPresent =
-                    Objects.nonNull(
-                            userInfo.getClaim(
-                                    "https://vocab.account.gov.uk/v1/socialSecurityRecord"));
             model.put("address_claim_present", addressClaimPresent);
             model.put("passport_claim_present", passportClaimPresent);
             model.put("driving_permit_claim_present", drivingPermitClaimPresent);
-            model.put("social_security_record_claim_present", socialSecurityRecordClaimPresent);
             model.put("locale_claim", userInfo.getClaim("locale"));
         }
         model.put("my_account_url", relyingPartyConfig.accountManagementUrl());

--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -150,15 +150,6 @@ public class AuthorizeHandler implements Route {
                 claimsSetRequest = claimsSetRequest.add(drivingPermitEntry);
             }
 
-            if (formParameters.containsKey("claims-social-security-record")) {
-                LOG.info("Social security record claim requested");
-                var socialSecurityRecordEntry =
-                        new ClaimsSetRequest.Entry(
-                                        formParameters.get("claims-social-security-record"))
-                                .withClaimRequirement(ClaimRequirement.ESSENTIAL);
-                claimsSetRequest = claimsSetRequest.add(socialSecurityRecordEntry);
-            }
-
             if (formParameters.containsKey("claims-return-code")) {
                 LOG.info("Return code claim requested");
                 var returnCodeEntry =

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -249,12 +249,6 @@
                                 </label>
                             </div>
                             <div class="govuk-checkboxes__item">
-                                <input class="govuk-checkboxes__input" id="claims-social-security-record" name="claims-social-security-record" type="checkbox" value="https://vocab.account.gov.uk/v1/socialSecurityRecord">
-                                <label class="govuk-label govuk-checkboxes__label" for="claims-social-security-record">
-                                    social security record
-                                </label>
-                            </div>
-                            <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="claims-return-code" name="claims-return-code" type="checkbox" value="https://vocab.account.gov.uk/v1/returnCode">
                                 <label class="govuk-label govuk-checkboxes__label" for="claims-return-code">
                                     return code

--- a/src/main/resources/templates/userinfo.mustache
+++ b/src/main/resources/templates/userinfo.mustache
@@ -147,14 +147,6 @@
                     </div>
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
-                            Social Security Record Claim Present
-                        </dt>
-                        <dd class="govuk-summary-list__value" id="user-info-social-security-record-claim-present">
-                            {{social_security_record_claim_present}}
-                        </dd>
-                    </div>
-                    <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">
                             Return Code Claim Present
                         </dt>
                         <dd class="govuk-summary-list__value" id="user-info-return-code-claim-present">

--- a/template.yaml
+++ b/template.yaml
@@ -55,6 +55,13 @@ Globals:
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
 
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E3031
+        - W8003
+
 Mappings:
   EnvironmentConfiguration:
     dev:


### PR DESCRIPTION
## What?
- Removes the `SocialSecurityRecord` claim from the stub

## Why?: 
- We stopped supporting this claim a while ago and are now removing it 