### PR TITLE
Revert "BAU: Pin jetty-http due to CVE-2024-6763"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ dependencies {
         implementation("org.eclipse.jetty:jetty-server:[10.0.23,11)")
         implementation("org.eclipse.jetty:jetty-webapp:[10.0.23,11)")
         implementation("io.netty:netty-common:[4.1.115.Final,4.2)")
-        implementation("org.eclipse.jetty:jetty-http:[12.0.12,12.1)")
     }
 
     implementation(platform("software.amazon.awssdk:bom:2.28.19"))


### PR DESCRIPTION
Reverts govuk-one-login/relying-party-stub#418

This PR breaks the build. The vulnerability is not relevant to jetty-http v10, as discussed in this thread: https://github.com/jetty/jetty.project/pull/12012

Also, since we don't directly use the dependency and instead use it through another jetty package, the thread confirms that we are not subject to the vulnerability