### PR TITLE
ATO-1464: add PKCE support

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -29,9 +29,17 @@ public class AuthCallbackHandler implements Route {
                 Configuration.getRelyingPartyConfig(request.cookie("relyingParty"));
         var oidcClient = new Oidc(relyingPartyConfig);
         var validator = CoreIdentityValidator.createValidator(relyingPartyConfig);
+
+        var codeVerifierValue = request.cookie("codeVerifier");
+        if (codeVerifierValue != null) {
+            response.removeCookie("/", "codeVerifier");
+        }
+
         var tokens =
                 oidcClient.makeTokenRequest(
-                        request.queryParams("code"), relyingPartyConfig.authCallbackUrl());
+                        request.queryParams("code"),
+                        relyingPartyConfig.authCallbackUrl(),
+                        codeVerifierValue);
         oidcClient.validateIdToken(tokens.getIDToken());
         response.cookie("/", "idToken", tokens.getIDToken().getParsedString(), 3600, false, true);
         var userInfo = oidcClient.makeUserInfoRequest(tokens.getAccessToken());

--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -206,6 +206,8 @@ public class AuthorizeHandler implements Route {
             if (formParameters.containsKey("pkce") && formParameters.get("pkce").equals("yes")) {
                 codeChallengeMethod = CodeChallengeMethod.S256;
                 codeVerifier = new CodeVerifier();
+
+                response.cookie("/", "codeVerifier", codeVerifier.getValue(), 3600, false, true);
             }
 
             var authRequest =

--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -10,6 +10,8 @@ import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.pkce.CodeChallengeMethod;
+import com.nimbusds.oauth2.sdk.pkce.CodeVerifier;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.claims.ClaimRequirement;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
@@ -198,6 +200,14 @@ public class AuthorizeHandler implements Route {
                 }
             }
 
+            CodeChallengeMethod codeChallengeMethod = null;
+            CodeVerifier codeVerifier = null;
+
+            if (formParameters.containsKey("pkce") && formParameters.get("pkce").equals("yes")) {
+                codeChallengeMethod = CodeChallengeMethod.S256;
+                codeVerifier = new CodeVerifier();
+            }
+
             var authRequest =
                     buildAuthorizeRequest(
                             relyingPartyConfig,
@@ -210,7 +220,9 @@ public class AuthorizeHandler implements Route {
                             prompt,
                             rpSid,
                             idToken,
-                            maxAge);
+                            maxAge,
+                            codeChallengeMethod,
+                            codeVerifier);
 
             if (formParameters.containsKey("method")
                     && formParameters.get("method").equals("post")) {
@@ -260,7 +272,9 @@ public class AuthorizeHandler implements Route {
             String prompt,
             String rpSid,
             String idToken,
-            String maxAge)
+            String maxAge,
+            CodeChallengeMethod codeChallengeMethod,
+            CodeVerifier codeVerifier)
             throws URISyntaxException {
         if ("object".equals(formParameters.getOrDefault("request", "query"))) {
             LOG.info("Building authorize request with JAR");
@@ -273,7 +287,9 @@ public class AuthorizeHandler implements Route {
                     prompt,
                     rpSid,
                     idToken,
-                    maxAge);
+                    maxAge,
+                    codeChallengeMethod,
+                    codeVerifier);
         } else {
             LOG.info("Building authorize request with query params");
             return oidcClient.buildQueryParamAuthorizeRequest(
@@ -284,7 +300,9 @@ public class AuthorizeHandler implements Route {
                     language,
                     prompt,
                     rpSid,
-                    maxAge);
+                    maxAge,
+                    codeChallengeMethod,
+                    codeVerifier);
         }
     }
 }

--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -116,12 +116,16 @@ public class Oidc {
         return userInfoResponse.toSuccessResponse().getUserInfo();
     }
 
-    public OIDCTokens makeTokenRequest(String authCode, String authCallbackUrl)
+    public OIDCTokens makeTokenRequest(
+            String authCode, String authCallbackUrl, String codeVerifierValue)
             throws URISyntaxException {
         LOG.info("Making Token Request");
+
+        var codeVerifier = (codeVerifierValue != null) ? new CodeVerifier(codeVerifierValue) : null;
+
         var codeGrant =
                 new AuthorizationCodeGrant(
-                        new AuthorizationCode(authCode), new URI(authCallbackUrl));
+                        new AuthorizationCode(authCode), new URI(authCallbackUrl), codeVerifier);
 
         try {
             var clientAuthentication =

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -349,6 +349,7 @@
                         <input class="govuk-input" id="rp-sid" name="rp-sid" type="text">
                     </fieldset>
                 </div>
+
                 <div class="govuk-grid-column-one-quarter govuk-form-group">
                     <fieldset class="govuk-fieldset">
                         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
@@ -367,6 +368,28 @@
                                 <input class="govuk-radios__input" id="request-object" name="request" type="radio" value="object">
                                 <label class="govuk-label govuk-radios__label" for="request-object">
                                     Request Object
+                                </label>
+                            </div>
+                        </div>
+
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-top-6">
+                            <h3 class="govuk-fieldset__heading">
+                                PKCE
+                            </h3>
+                        </legend>
+                        <div class="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="pkce-yes" name="pkce" type="radio"
+                                       value="yes">
+                                <label class="govuk-label govuk-radios__label" for="pkce-yes">
+                                    Yes
+                                </label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="pkce-no" name="pkce" type="radio"
+                                       value="no" checked>
+                                <label class="govuk-label govuk-radios__label" for="pkce-no">
+                                    No
                                 </label>
                             </div>
                         </div>

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -317,43 +317,37 @@
                 </div>
 
                 <div class="govuk-grid-column-one-quarter govuk-form-group">
-                    <div class="govuk-grid-row">
-                        <fieldset class="govuk-fieldset">
-                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                                <h3 class="govuk-fieldset__heading">
-                                    HTTP METHOD
-                                </h3>
-                            </legend>
-                            <div class="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="method-get" name="method" type="radio"
-                                           value="get" checked>
-                                    <label class="govuk-label govuk-radios__label" for="method-get">
-                                        GET
-                                    </label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="method-post" name="method" type="radio"
-                                           value="post">
-                                    <label class="govuk-label govuk-radios__label" for="method-post">
-                                        POST
-                                    </label>
-                                </div>
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                            <h3 class="govuk-fieldset__heading">
+                                HTTP METHOD
+                            </h3>
+                        </legend>
+                        <div class="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="method-get" name="method" type="radio"
+                                       value="get" checked>
+                                <label class="govuk-label govuk-radios__label" for="method-get">
+                                    GET
+                                </label>
                             </div>
-                        </fieldset>
-                    </div>
-                    <div class="govuk-grid-row">
-                        <fieldset class="govuk-fieldset govuk-!-margin-top-6">
-                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                                <h3 class="govuk-fieldset__heading">
-                                    <label class="govuk-label govuk-label--m" for="rp-sid">
-                                        RP Session ID (rp_sid)
-                                    </label>
-                                </h3>
-                            </legend>
-                            <input class="govuk-input" id="rp-sid" name="rp-sid" type="text">
-                        </fieldset>
-                    </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="method-post" name="method" type="radio"
+                                       value="post">
+                                <label class="govuk-label govuk-radios__label" for="method-post">
+                                    POST
+                                </label>
+                            </div>
+                        </div>
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-top-6">
+                            <h3 class="govuk-fieldset__heading">
+                                <label class="govuk-label govuk-label--m" for="rp-sid">
+                                    RP Session ID (rp_sid)
+                                </label>
+                            </h3>
+                        </legend>
+                        <input class="govuk-input" id="rp-sid" name="rp-sid" type="text">
+                    </fieldset>
                 </div>
                 <div class="govuk-grid-column-one-quarter govuk-form-group">
                     <fieldset class="govuk-fieldset">
@@ -371,7 +365,7 @@
                             </div>
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="request-object" name="request" type="radio" value="object">
-                                <label class="govuk-label govuk-radios__label" for="request-query-params">
+                                <label class="govuk-label govuk-radios__label" for="request-object">
                                     Request Object
                                 </label>
                             </div>


### PR DESCRIPTION
## What?

- Added PKCE toggle to UI
- New code verifier initialised each time we hit the `authorize` handler (to ensure this value is short-lived (only used once))
- Updated `authorize` request builders to support PKCE if a code verifier is supplied
- `Authorize callback` handler passes the code verifier (if defined) to initialise the code grant
  - Wipes the cookie (if defined) after reading to allow the PKCE off/"no" case to be immediately tested

## Why?

We are adding PKCE support to `authentication-api`, the RP stub needs to be updated to reflect this.

## Screenshots

UI changes (new PKCE toggle, fixed the overflow for the grid item to the left of the PKCE grid item):

<img width="682" alt="UI changes" src="https://github.com/user-attachments/assets/b0e9a1ea-3653-4017-a330-86b455dcb9a8" />
