### PR TITLE
ATO-1627: add login_hint

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -210,6 +210,13 @@ public class AuthorizeHandler implements Route {
                 response.cookie("/", "codeVerifier", codeVerifier.getValue(), 3600, false, true);
             }
 
+            String loginHint = null;
+
+            if (formParameters.containsKey("login-hint")
+                    && "object".equals(formParameters.getOrDefault("request", "query"))) {
+                loginHint = formParameters.get("login-hint");
+            }
+
             var authRequest =
                     buildAuthorizeRequest(
                             relyingPartyConfig,
@@ -224,7 +231,8 @@ public class AuthorizeHandler implements Route {
                             idToken,
                             maxAge,
                             codeChallengeMethod,
-                            codeVerifier);
+                            codeVerifier,
+                            loginHint);
 
             if (formParameters.containsKey("method")
                     && formParameters.get("method").equals("post")) {
@@ -276,7 +284,8 @@ public class AuthorizeHandler implements Route {
             String idToken,
             String maxAge,
             CodeChallengeMethod codeChallengeMethod,
-            CodeVerifier codeVerifier)
+            CodeVerifier codeVerifier,
+            String loginHint)
             throws URISyntaxException {
         if ("object".equals(formParameters.getOrDefault("request", "query"))) {
             LOG.info("Building authorize request with JAR");
@@ -291,7 +300,8 @@ public class AuthorizeHandler implements Route {
                     idToken,
                     maxAge,
                     codeChallengeMethod,
-                    codeVerifier);
+                    codeVerifier,
+                    loginHint);
         } else {
             LOG.info("Building authorize request with query params");
             return oidcClient.buildQueryParamAuthorizeRequest(

--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -200,7 +200,8 @@ public class Oidc {
             String idToken,
             String maxAge,
             CodeChallengeMethod codeChallengeMethod,
-            CodeVerifier codeVerifier)
+            CodeVerifier codeVerifier,
+            String loginHint)
             throws RuntimeException {
         LOG.info("Building JAR Authorize Request");
         JSONArray jsonArray = new JSONArray();
@@ -256,6 +257,10 @@ public class Oidc {
 
             var codeChallenge = CodeChallenge.compute(codeChallengeMethod, codeVerifier);
             requestObject.claim("code_challenge", codeChallenge.getValue());
+        }
+
+        if (loginHint != null && !loginHint.isBlank()) {
+            requestObject.claim("login_hint", loginHint);
         }
 
         return new AuthenticationRequest.Builder(

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -396,6 +396,20 @@
                     </fieldset>
                 </div>
 
+                <div class="govuk-grid-column-one-quarter govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-top-6">
+                            <h3 class="govuk-fieldset__heading">
+                                <label class="govuk-label govuk-label--m" for="login-hint">
+                                    Login hint
+                                </label>
+                            </h3>
+                            <p class="govuk-body">(Not supported for Query Params)</p>
+                        </legend>
+                        <input class="govuk-input" id="login-hint" name="login-hint" type="text">
+                    </fieldset>
+                </div>
+
                 <div class="govuk-grid-column-full">
                 <button data-prevent-double-click="true" class="govuk-button" id="govuk-signin-button" data-module="govuk-button" type="submit">
                     Continue

--- a/src/test/java/uk/gov/di/utils/OidcTest.java
+++ b/src/test/java/uk/gov/di/utils/OidcTest.java
@@ -62,6 +62,7 @@ public class OidcTest {
                         "",
                         "123",
                         null,
+                        null,
                         null);
 
         var jarClaims = authorizeRequest.getRequestObject().getJWTClaimsSet();
@@ -92,7 +93,8 @@ public class OidcTest {
                         "",
                         "123",
                         codeChallengeMethod,
-                        codeVerifier);
+                        codeVerifier,
+                        null);
 
         var jarClaims = authorizeRequest.getRequestObject().getJWTClaimsSet();
         var expectedClaims = new OIDCClaimsRequest().withUserInfoClaimsRequest(testClaimSetRequest);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/96524057-c291-4682-b292-a5e85ea8e873)

I didn't like pushing it under another item so it's on it's own row

## What?

As part of the login_hint work, need to be able to add login_hint (email). It won't be passed on if it comes from query params.

For now ignore second commit as that will be removed, it's only been added for testing

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/6512
