### PR TITLE
BAU: Use valid cosign version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
         with:
-          cosign-release: 'v1.9.0'
+          cosign-release: 'v2.5.3'
 
       - name: Build, tag, sign and push image to Amazon ECR
         env:


### PR DESCRIPTION
## What?

We recently merged in a dependabot PR to update the `cosign-installer` dependency. This requires us to use a cosign version of at least v2.0.0. We are currently requesting v1.9.0 so this GHA fails (see https://github.com/govuk-one-login/relying-party-stub/actions/runs/16751577799/job/47423081611)

This PR requests the latest cosign version (v2.5.3). I deployed and tested this in dev and the deployment was successful
