### PR TITLE
BAU: Bump netty-codec-http2 to 4.1.124+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ dependencies {
         implementation("org.eclipse.jetty:jetty-server:[10.0.23,11)")
         implementation("org.eclipse.jetty:jetty-webapp:[10.0.23,11)")
         implementation("io.netty:netty-common:[4.1.115.Final,4.2)")
+        implementation('io.netty:netty-codec-http2') {
+            version { strictly '[4.1.124.Final,4.2.0)' }
+            because 'CVE-2025-55163 is fixed in io.netty:netty-codec-http2:4.1.124.Final and higher'
+        }
     }
 
     implementation(platform("software.amazon.awssdk:bom:2.30.21"))


### PR DESCRIPTION
## What?

Requires netty-codec-http2 from 4.1.118 Final to use 4.1.124 Final or above.

## Why?

Resolving CVE-2025-55163