### PR TITLE
ATO-2237 - Resolve netty vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
             version { strictly '[4.1.125.Final,4.2.0)' }
             because 'CVE-2025-58056 and CVE-2025-58057 ars fixed in io.netty:netty-codec-http2:4.1.125.Final and higher'
         }
+        implementation('io.netty:netty-codec-http') {
+            version { strictly '[4.1.129.Final,4.2.0)' }
+            because 'CVE-2025-67735 fixed in io.netty:netty-codec-http:4.1.129.Final and higher'
+        }
     }
 
     implementation(platform("software.amazon.awssdk:bom:2.30.21"))


### PR DESCRIPTION
- enforce use of io.netty:netty-codec-http:4.1.129.Final and higher to fix CVE-2025-67735 (identified by [dependabot](https://github.com/govuk-one-login/relying-party-stub/security/dependabot/13))
- built successfully and successfully tested auth journey
