### PR TITLE
ATO-2260: Add option to select alternative domain

### DIFF
--- a/src/main/java/uk/gov/di/config/RPConfig.java
+++ b/src/main/java/uk/gov/di/config/RPConfig.java
@@ -16,7 +16,8 @@ public record RPConfig(
         String serviceName,
         String opBaseUrl,
         String tokenClientSecret,
-        String inheritedIdentityJwtSigningKey) {
+        String inheritedIdentityJwtSigningKey,
+        String alternativeBaseUrl) {
 
     private static final String kid = UUID.randomUUID().toString();
 

--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -36,15 +36,17 @@ public class AuthCallbackHandler implements Route {
         if (codeVerifierValue != null) {
             response.removeCookie("/", "codeVerifier");
         }
-
+        var useAlternativeDomain = "true".equals(request.cookie("useAlternativeDomain"));
         var tokens =
                 oidcClient.makeTokenRequest(
                         request.queryParams("code"),
                         relyingPartyConfig.authCallbackUrl(),
-                        codeVerifierValue);
-        oidcClient.validateIdToken(tokens.getIDToken());
+                        codeVerifierValue,
+                        useAlternativeDomain);
+        oidcClient.validateIdToken(tokens.getIDToken(), useAlternativeDomain);
         response.cookie("/", "idToken", tokens.getIDToken().getParsedString(), 3600, false, true);
-        var userInfo = oidcClient.makeUserInfoRequest(tokens.getAccessToken());
+        var userInfo =
+                oidcClient.makeUserInfoRequest(tokens.getAccessToken(), useAlternativeDomain);
 
         var model = new HashMap<>();
         model.put("id_token", tokens.getIDToken().getParsedString());

--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -72,11 +72,13 @@ public class AuthorizeHandler implements Route {
             if (relyingPartyConfig.clientType().equals("app")) {
                 LOG.info("Doc Checking App journey initialized");
                 scopes.add("doc-checking-app");
+                var useAlternativeDomain = "true".equals(request.cookie("useAlternativeDomain"));
                 var opURL =
                         oidcClient.buildDocAppAuthorizeRequest(
                                 relyingPartyConfig.authCallbackUrl(),
                                 Scope.parse(scopes),
-                                language);
+                                language,
+                                useAlternativeDomain);
                 LOG.info("Redirecting to OP");
                 response.redirect(opURL);
                 return null;
@@ -250,7 +252,7 @@ public class AuthorizeHandler implements Route {
             if (!Objects.equals(formParameters.get("channel"), "none")) {
                 channel = formParameters.get("channel");
             }
-
+            var useAlternativeDomain = "true".equals(request.cookie("useAlternativeDomain"));
             var authRequest =
                     buildAuthorizeRequest(
                             relyingPartyConfig,
@@ -267,7 +269,8 @@ public class AuthorizeHandler implements Route {
                             codeChallengeMethod,
                             codeVerifier,
                             loginHint,
-                            channel);
+                            channel,
+                            useAlternativeDomain);
 
             LOG.info("Redirecting to OP");
             response.redirect(authRequest.toURI().toString());
@@ -306,7 +309,8 @@ public class AuthorizeHandler implements Route {
             CodeChallengeMethod codeChallengeMethod,
             CodeVerifier codeVerifier,
             String loginHint,
-            String channel)
+            String channel,
+            boolean useAlternativeDomain)
             throws URISyntaxException {
         if ("object".equals(formParameters.getOrDefault("request", "query"))) {
             LOG.info("Building authorize request with JAR");
@@ -323,7 +327,8 @@ public class AuthorizeHandler implements Route {
                     codeChallengeMethod,
                     codeVerifier,
                     loginHint,
-                    channel);
+                    channel,
+                    useAlternativeDomain);
         } else {
             LOG.info("Building authorize request with query params");
             return oidcClient.buildQueryParamAuthorizeRequest(
@@ -337,7 +342,8 @@ public class AuthorizeHandler implements Route {
                     maxAge,
                     codeChallengeMethod,
                     codeVerifier,
-                    channel);
+                    channel,
+                    useAlternativeDomain);
         }
     }
 }

--- a/src/main/java/uk/gov/di/handlers/BackChannelLogoutHandler.java
+++ b/src/main/java/uk/gov/di/handlers/BackChannelLogoutHandler.java
@@ -31,12 +31,12 @@ public class BackChannelLogoutHandler implements Route {
                 URLEncodedUtils.parse(request.body(), defaultCharset()).stream()
                         .collect(toMap(NameValuePair::getName, NameValuePair::getValue))
                         .getOrDefault("logout_token", "");
-
+        var useAlternativeDomain = "true".equals(request.cookie("useAlternativeDomain"));
         try {
             var jwt = SignedJWT.parse(payload);
 
             oidcClient
-                    .validateLogoutToken(jwt)
+                    .validateLogoutToken(jwt, useAlternativeDomain)
                     .map(ClaimsSet::toJSONString)
                     .ifPresentOrElse(
                             claims -> {

--- a/src/main/java/uk/gov/di/handlers/HomeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/HomeHandler.java
@@ -27,6 +27,7 @@ public class HomeHandler implements Route {
         var relyingPartyConfig = Configuration.getRelyingPartyConfig(relyingPartyString);
         var model = new HashMap<>();
         model.put("servicename", relyingPartyConfig.serviceName());
+        model.put("useAlternativeDomain", "true".equals(request.cookie("useAlternativeDomain")));
         LOG.info(
                 "Rendering RP with serviceName: {} and clientType: {}",
                 relyingPartyConfig.serviceName(),

--- a/src/main/java/uk/gov/di/handlers/RelyingPartyGetHandler.java
+++ b/src/main/java/uk/gov/di/handlers/RelyingPartyGetHandler.java
@@ -13,6 +13,7 @@ public class RelyingPartyGetHandler implements Route {
     public Object handle(Request request, Response response) throws Exception {
         var model = new HashMap<>();
         model.put("relyingParties", Configuration.getInstance().values().stream().toList());
+        model.put("useAlternativeDomain", "true".equals(request.cookie("useAlternativeDomain")));
         return ViewHelper.render(model, "relying-parties.mustache");
     }
 }

--- a/src/main/java/uk/gov/di/handlers/RelyingPartyPostHandler.java
+++ b/src/main/java/uk/gov/di/handlers/RelyingPartyPostHandler.java
@@ -22,6 +22,11 @@ public class RelyingPartyPostHandler implements Route {
 
         response.cookie(
                 "/", "relyingParty", formParameters.get("relying-party"), 3600, false, true);
+        if ("on".equals(formParameters.get("use-alternative-domain"))) {
+            response.cookie("/", "useAlternativeDomain", "true", 3600, false, true);
+        } else {
+            response.removeCookie("/", "useAlternativeDomain");
+        }
         response.redirect("/");
         return null;
     }

--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -73,6 +73,7 @@ public class Oidc {
     private final RPConfig relyingPartyConfig;
 
     private final OIDCProviderMetadata providerMetadata;
+    private final Optional<OIDCProviderMetadata> alternativeProviderMetadata;
     private final String idpUrl;
     private final ClientID clientId;
     private final PrivateKeyReader privateKeyReader;
@@ -82,6 +83,9 @@ public class Oidc {
         this.idpUrl = relyingPartyConfig.opBaseUrl();
         this.clientId = new ClientID(relyingPartyConfig.clientId());
         this.providerMetadata = loadProviderMetadata(idpUrl);
+        this.alternativeProviderMetadata =
+                Optional.ofNullable(relyingPartyConfig.alternativeBaseUrl())
+                        .map(this::loadProviderMetadata);
         this.privateKeyReader = new PrivateKeyReader(relyingPartyConfig.clientPrivateKey());
     }
 
@@ -94,13 +98,14 @@ public class Oidc {
         }
     }
 
-    public UserInfo makeUserInfoRequest(AccessToken accessToken)
+    public UserInfo makeUserInfoRequest(AccessToken accessToken, boolean useAlternativeDomain)
             throws IOException, ParseException {
         LOG.info("Making userinfo request");
+        var userInfoEndpointURI =
+                getProviderMetadata(useAlternativeDomain).getUserInfoEndpointURI();
         var httpResponse =
                 new UserInfoRequest(
-                                this.providerMetadata.getUserInfoEndpointURI(),
-                                new BearerAccessToken(accessToken.toString()))
+                                userInfoEndpointURI, new BearerAccessToken(accessToken.toString()))
                         .toHTTPRequest()
                         .send();
 
@@ -117,7 +122,10 @@ public class Oidc {
     }
 
     public OIDCTokens makeTokenRequest(
-            String authCode, String authCallbackUrl, String codeVerifierValue)
+            String authCode,
+            String authCallbackUrl,
+            String codeVerifierValue,
+            boolean useAlternativeDomain)
             throws URISyntaxException {
         LOG.info("Making Token Request");
 
@@ -128,19 +136,15 @@ public class Oidc {
                         new AuthorizationCode(authCode), new URI(authCallbackUrl), codeVerifier);
 
         try {
+            var tokenEndpointURI = getProviderMetadata(useAlternativeDomain).getTokenEndpointURI();
             var clientAuthentication =
                     Optional.ofNullable(relyingPartyConfig.tokenClientSecret())
                             .map(this::clientSecretPost)
-                            .orElseGet(this::privateKeyJwt);
+                            .orElseGet(() -> privateKeyJwt(tokenEndpointURI));
 
             var request =
                     new TokenRequest(
-                            this.providerMetadata.getTokenEndpointURI(),
-                            clientAuthentication,
-                            codeGrant,
-                            null,
-                            null,
-                            null);
+                            tokenEndpointURI, clientAuthentication, codeGrant, null, null, null);
 
             var tokenResponse = OIDCTokenResponseParser.parse(request.toHTTPRequest().send());
 
@@ -173,7 +177,7 @@ public class Oidc {
         return new ClientSecretPost(new ClientID(this.clientId), new Secret(secret));
     }
 
-    private ClientAuthentication privateKeyJwt() {
+    private ClientAuthentication privateKeyJwt(URI tokenEndpointURI) {
         var localDateTime = LocalDateTime.now().plusMinutes(5);
         var expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
 
@@ -181,7 +185,7 @@ public class Oidc {
                 new JWTClaimsSet.Builder()
                         .subject(this.clientId.getValue())
                         .issuer(this.clientId.getValue())
-                        .audience(this.providerMetadata.getTokenEndpointURI().toString())
+                        .audience(tokenEndpointURI.toString())
                         .expirationTime(expiryDate)
                         .claim("client_id", this.clientId)
                         .build();
@@ -202,9 +206,11 @@ public class Oidc {
             CodeChallengeMethod codeChallengeMethod,
             CodeVerifier codeVerifier,
             String loginHint,
-            String channel)
+            String channel,
+            boolean useAlternativeDomain)
             throws RuntimeException {
         LOG.info("Building JAR Authorize Request");
+        var endpointURI = getProviderMetadata(useAlternativeDomain).getAuthorizationEndpointURI();
         Prompt authRequestPrompt;
         try {
             authRequestPrompt = Prompt.parse(prompt);
@@ -216,7 +222,7 @@ public class Oidc {
                 new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
         var requestObject =
                 new JWTClaimsSet.Builder()
-                        .audience(this.providerMetadata.getAuthorizationEndpointURI().toString())
+                        .audience(endpointURI.toString())
                         .claim("redirect_uri", callbackUrl)
                         .claim("response_type", ResponseType.CODE.toString())
                         .claim("scope", Scope.parse(scopes).toString())
@@ -268,7 +274,7 @@ public class Oidc {
 
         return new AuthenticationRequest.Builder(
                         ResponseType.CODE, Scope.parse(scopes), this.clientId, null)
-                .endpointURI(this.providerMetadata.getAuthorizationEndpointURI())
+                .endpointURI(endpointURI)
                 .requestObject(signJwtWithClaims(requestObject.build()))
                 .build();
     }
@@ -284,7 +290,8 @@ public class Oidc {
             String maxAge,
             CodeChallengeMethod codeChallengeMethod,
             CodeVerifier codeVerifier,
-            String channel)
+            String channel,
+            boolean useAlternativeDomain)
             throws URISyntaxException, RuntimeException {
         LOG.info("Building Authorize Request");
         Prompt authRequestPrompt;
@@ -293,7 +300,7 @@ public class Oidc {
         } catch (ParseException e) {
             throw new RuntimeException("Unable to parse prompt", e);
         }
-
+        var endpointURI = getProviderMetadata(useAlternativeDomain).getAuthorizationEndpointURI();
         var authorizationRequestBuilder =
                 new AuthenticationRequest.Builder(
                                 new ResponseType(ResponseType.Value.CODE),
@@ -303,7 +310,7 @@ public class Oidc {
                         .state(new State())
                         .nonce(new Nonce())
                         .prompt(authRequestPrompt)
-                        .endpointURI(this.providerMetadata.getAuthorizationEndpointURI())
+                        .endpointURI(endpointURI)
                         .customParameter("vtr", JSONArray.toJSONString(vtr));
 
         if (Objects.nonNull(codeVerifier)) {
@@ -342,18 +349,19 @@ public class Oidc {
         return authorizationRequestBuilder.build();
     }
 
-    public String getAuthorizationEndpoint() {
-        return this.providerMetadata.getAuthorizationEndpointURI().toString();
-    }
-
-    public String buildDocAppAuthorizeRequest(String callbackUrl, Scope scopes, String language) {
+    public String buildDocAppAuthorizeRequest(
+            String callbackUrl, Scope scopes, String language, boolean useAlternativeDomain) {
         LOG.info("Building secure Authorize Request");
         var authRequestBuilder =
                 new AuthorizationRequest.Builder(
                                 new ResponseType(ResponseType.Value.CODE), this.clientId)
-                        .requestObject(generateSignedJWT(scopes, callbackUrl, language))
+                        .requestObject(
+                                generateSignedJWT(
+                                        scopes, callbackUrl, language, useAlternativeDomain))
                         .scope(new Scope(OIDCScopeValue.OPENID))
-                        .endpointURI(this.providerMetadata.getAuthorizationEndpointURI());
+                        .endpointURI(
+                                getProviderMetadata(useAlternativeDomain)
+                                        .getAuthorizationEndpointURI());
 
         return authRequestBuilder.build().toURI().toString();
     }
@@ -369,15 +377,17 @@ public class Oidc {
         return logoutUri.build().toString();
     }
 
-    public void validateIdToken(JWT idToken) throws MalformedURLException {
+    public void validateIdToken(JWT idToken, boolean useAlternativeDomain)
+            throws MalformedURLException {
         LOG.info("Validating ID token");
         ResourceRetriever resourceRetriever = new DefaultResourceRetriever(30000, 30000);
+        var providerMetadata = getProviderMetadata(useAlternativeDomain);
         var idTokenValidator =
                 new IDTokenValidator(
-                        this.providerMetadata.getIssuer(),
+                        providerMetadata.getIssuer(),
                         this.clientId,
                         JWSAlgorithm.parse(this.relyingPartyConfig.idTokenSigningAlgorithm()),
-                        this.providerMetadata.getJWKSetURI().toURL(),
+                        providerMetadata.getJWKSetURI().toURL(),
                         resourceRetriever);
 
         try {
@@ -388,14 +398,16 @@ public class Oidc {
         }
     }
 
-    public Optional<LogoutTokenClaimsSet> validateLogoutToken(JWT logoutToken) {
+    public Optional<LogoutTokenClaimsSet> validateLogoutToken(
+            JWT logoutToken, boolean useAlternativeDomain) {
         try {
+            var providerMetadata = getProviderMetadata(useAlternativeDomain);
             var validator =
                     new LogoutTokenValidator(
-                            this.providerMetadata.getIssuer(),
+                            providerMetadata.getIssuer(),
                             this.clientId,
                             JWSAlgorithm.parse(relyingPartyConfig.idTokenSigningAlgorithm()),
-                            this.providerMetadata.getJWKSetURI().toURL(),
+                            providerMetadata.getJWKSetURI().toURL(),
                             new DefaultResourceRetriever(30000, 30000));
 
             return Optional.of(validator.validate(logoutToken));
@@ -413,10 +425,14 @@ public class Oidc {
         }
     }
 
-    private SignedJWT generateSignedJWT(Scope scopes, String callbackURL, String language) {
+    private SignedJWT generateSignedJWT(
+            Scope scopes, String callbackURL, String language, boolean useAlternativeDomain) {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
-                        .audience(this.providerMetadata.getAuthorizationEndpointURI().toString())
+                        .audience(
+                                getProviderMetadata(useAlternativeDomain)
+                                        .getAuthorizationEndpointURI()
+                                        .toString())
                         .subject(new Subject().getValue())
                         .claim("redirect_uri", callbackURL)
                         .claim("response_type", ResponseType.CODE.toString())
@@ -450,5 +466,14 @@ public class Oidc {
         }
 
         return signedJWT;
+    }
+
+    private OIDCProviderMetadata getProviderMetadata(boolean useAlternativeDomain) {
+        if (useAlternativeDomain && this.alternativeProviderMetadata.isPresent()) {
+            LOG.info("Using alternative domain");
+            return this.alternativeProviderMetadata.get();
+        } else {
+            return this.providerMetadata;
+        }
     }
 }

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -63,6 +63,9 @@
             <h1 class="govuk-heading-xl">
                 {{servicename}}
             </h1>
+            {{#useAlternativeDomain}}
+              <h3 class="govuk-heading-m">Using alternative domain</h3>
+            {{/useAlternativeDomain}}
         </div>
         <div class="govuk-grid-row">
             <form method="post" action="/oidc/auth">
@@ -366,6 +369,11 @@
                                 </label>
                             </div>
                         </div>
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-top-6">
+                            <h3 class="govuk-fieldset__heading">
+                                Use alternative domain
+                            </h3>
+                        </legend>
                     </fieldset>
                 </div>
 

--- a/src/main/resources/templates/relying-parties.mustache
+++ b/src/main/resources/templates/relying-parties.mustache
@@ -68,9 +68,17 @@
                                 <option value="{{clientId}}">{{serviceName}}</option>
                             {{/relyingParties}}
                         </select>
+                        </div>
+                      <div class="govuk-form-group">
+                        <div class="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                              <input class="govuk-checkboxes__input" type="checkbox" name="use-alternative-domain" id="use-alternative-domain"{{#useAlternativeDomain}} checked {{/useAlternativeDomain}}/>
+                              <label class="govuk-label govuk-checkboxes__label" for="use-alternative-domain">Use alternative domain (if present)</label>
+                            </div>
+                        </div>
+                       </div>
                     </div>
-
-                    <button class="govuk-button" type="submit">Submit</button>
+                  <button class="govuk-button" type="submit">Submit</button>
                 </form>
             </div>
         </div>

--- a/src/test/java/uk/gov/di/utils/OidcTest.java
+++ b/src/test/java/uk/gov/di/utils/OidcTest.java
@@ -81,7 +81,8 @@ public class OidcTest {
                         null,
                         null,
                         null,
-                        "web");
+                        "web",
+                        false);
 
         var jarClaims = authorizeRequest.getRequestObject().getJWTClaimsSet();
         var expectedClaims = new OIDCClaimsRequest().withUserInfoClaimsRequest(testClaimSetRequest);
@@ -113,7 +114,8 @@ public class OidcTest {
                         codeChallengeMethod,
                         codeVerifier,
                         null,
-                        "web");
+                        "web",
+                        false);
 
         var jarClaims = authorizeRequest.getRequestObject().getJWTClaimsSet();
         var expectedClaims = new OIDCClaimsRequest().withUserInfoClaimsRequest(testClaimSetRequest);
@@ -144,7 +146,8 @@ public class OidcTest {
                         "123",
                         null,
                         null,
-                        "web");
+                        "web",
+                        false);
 
         var jarClaims = authorizeRequest.toJWTClaimsSet();
         var expectedClaims = new OIDCClaimsRequest().withUserInfoClaimsRequest(testClaimSetRequest);
@@ -175,7 +178,8 @@ public class OidcTest {
                         "123",
                         codeChallengeMethod,
                         codeVerifier,
-                        "web");
+                        "web",
+                        false);
 
         var jarClaims = authorizeRequest.toJWTClaimsSet();
         var expectedClaims = new OIDCClaimsRequest().withUserInfoClaimsRequest(testClaimSetRequest);


### PR DESCRIPTION
## What?

Adds a checkbox to the change RP screen to use an alternative base URL defined in the config (`alternative_base_url`). If the config doesn't have this field, then this option is ignored and the base URL is used.
<img width="641" height="451" alt="image" src="https://github.com/user-attachments/assets/b7bd36c5-3aed-4e37-bddc-432bf6f9dc8d" />


## Why?

We would like to test different orch domains in the future

