### PR TITLE
ATO-2423: update gradle to no longer use jfrog (and reference danubetech instead)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,9 @@
 buildscript {
     repositories {
+        mavenCentral()
+
         maven {
-            url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
+            url 'https://repo.danubetech.com/repository/maven-public/'
         }
     }
 }
@@ -18,8 +20,10 @@ apply plugin: 'idea'
 group 'uk.gov.di'
 
 repositories {
+    mavenCentral()
+
     maven {
-        url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
+        url 'https://repo.danubetech.com/repository/maven-public/'
     }
 }
 


### PR DESCRIPTION
## What?

Remove jfrog and add danubetech and MavenCentral

## Why?

Due to reliability reasons, we are migrating away from using jfrog for our java dependencies, to maven central. However we still need `decentralized-identity:did-common-java` which MavenCentral does not publish publicly. So we need to reference danubetech instead.

Ran locally and it worked 👍  currently deploying to dev to double check
