### PR TITLE
BAU: Bump lambda to node22

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1076,7 +1076,7 @@ Resources:
       ReservedConcurrentExecutions: 1
       Handler: authorizer.handler
       MemorySize: 128
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 900
       Environment:
         Variables:


### PR DESCRIPTION

## What?:
- Bumps the authoriser lambda to node22

## Why?
- AWS are [deprecating support for the node20 runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
