### PR TITLE
BAU: Local running

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,4 @@
+DEFAULT_CLIENT_ID=local-rp-stub
+CONFIGURATION_SOURCE=local
+STUB_URL=http://localhost:4000
+PORT=4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:lts AS scripts
-
+# TODO: pin this
 COPY scripts .
 RUN npm install --ignore-scripts
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:lts AS scripts
-# TODO: pin this
+FROM node:22.20.0-alpine@sha256:cb3143549582cc5f74f26f0992cdef4a422b22128cb517f94173a5f910fa4ee7 AS scripts
+
 COPY scripts .
 RUN npm install --ignore-scripts
 
@@ -15,7 +15,7 @@ COPY --chown=gradle:gradle src src
 COPY --from=scripts /node_modules/jquery/dist/jquery.min.js src/main/resources/public/jquery.js
 RUN gradle clean build installDist --no-daemon
 
-FROM amazoncorretto:22.0.2-alpine3.17 AS runtime
+FROM amazoncorretto:21.0.10-alpine3.23@sha256:29fb96b59042d9637e3d51ff3b423be3a88f17f530cbfb767a91d4199457f395 AS runtime
 WORKDIR /home
 COPY --from=build /home/gradle/src/build/install/src .
 

--- a/README.MD
+++ b/README.MD
@@ -7,6 +7,9 @@ Once you have gone through the authentication/identity journey, you will be redi
 displaying the user info returned by the One Login service.
 
 ## Local Setup
+
+### Standalone against a deployed environment
+
 You'll need to set up environment variables to run locally. Make a copy of the `.env.template` file, and rename it `.env`.
 
 You will also need to set up your local configuration. Make a copy of the `config.json.template` file named `config.json`.
@@ -18,6 +21,12 @@ We typically run the stub against the build environment of One Login, as this ha
 To run the stub locally, run `docker compose up --build`.
 
 It will be accessible on port 8080.
+
+### As part of Orchestration local running
+
+If running as part of the orchestration local setup, the docker image is run and configured from the orchestration API codebase.
+
+In this scenario it runs on port 4000, and uses the config in `.env.local` and `config.local.json`.
 
 ## Configuration
 

--- a/config.local.json
+++ b/config.local.json
@@ -1,0 +1,13 @@
+{
+  "local-rp-stub" : {
+    "//": "This key is only for use in insecure local environments - i.e. the local orchestration API",
+    "client_private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCsYqyBB1dDgtGr\nA5njRB6Lskjvbu7b+VFoDl3Ji3uqgLyiVCA6bFOt9i2NCH52NSZVMDSOOCpN2ofB\nf4/jzhcpMwTA7ko98kDukgHAeN+JZsdovIPLAxOJKhOqmk+8zVFE45CH+oI3kRyV\n+TGKGulUx3MFhGfsVuR/X7LCw36qCAdyzMxxVXk8T+jCOkQ36fboiBqNZholBA2O\n0DoMK9QIo+M5tMC+zUGuuGU40AzD5eRcBIUD8LYbpcwSy5epyVMI/+z0Dq8UP4j7\nLzGzOen1/bibx/kbz2CHE7he+ydRKpsTzmj7BYvXI0qYAMlyPf51WkgbaqnR3J3X\nbEOj41d/AgMBAAECggEAG0S35+iAMnLboBMqQRZ8mc7NFb7ftCvnPNq6QDrlsti5\naMN+SO+WJGMC3UKA3/RUCM60HuPIjAHWTqf93A8KKooM+vMsCvTVYPJMqk8UgSN2\ncLK9SvGaIgI7aSsOvkgLeSZhgvj//IfiVIuTfWFOE+CW6RetlBJCA9oLU3QMMcYK\nYihvyrg5ixiwATAn5Ndwxkuc4ge3jE3gg5BjALR+6QTZZSoVtWtdwpKtf/XY+iIR\nll/zZKUsESoMh6Bfmb1sOTBsh0/xHjm9mckOfxj0SajshDWggHSZ3q3Yeb6Thbmm\nJhZDl68f89S42m6bXNVQWcsfzg28qr6TLZ4rVP0rQQKBgQDil1jzfRp4yIxjBMCs\nu0cBhOolDaSTaWNvNw4zrkfa7mWAVqEdKUm9OdurKVP4Oq9WsWNs8gT4yqBonImU\ny3icog0kIwuLmSK+5yVTgaZLSNjC6YCRkDXbgaJOaLvTVfdZvCHaCRsMznWrciHt\nacgWtcxC8r5hofwq13TarWu4QQKBgQDCwk1H1Ll2UU9K+J4Zma9geCxud81Ovhg1\nX6RUGgTK9xwhIE5rFXCbAgLl5K5hLcgsYqc1GpQizRPRRLDdpb6bP4hr4el5kZqk\nqXJQJSLZQZmtJVZ0VsWzpSWj54t7d8xpUQNN8F8R26xGgShTVPeFLt5KRfvfvELV\nI0l1H/UfvwKBgFPX4MgoEHWE771r8sd3fKypO+J+C9mn820hmBWzdU8jS1eTtoYN\n0wU7tXa+Eh4VyO9xL/MOEpzkjTpoQdhW+cgrhmVKumjrPxoYeY1OufO9fseQk0xJ\nakRQ0Xfl9Sob8yy3GmeNWv8AHjZUQw2QSMNufaiAHcYOpDpOAyUval6BAoGBAIKa\n5FJQUFMM8dy33uYSDu7lh/5IrtCoX/mi+sM/c4lcr2tzi8L57Lq2XZUnht06Y2uI\neNL+0OqJlkmXA/iPhsP7lhOquvRAdXEJBNTEIpuJB3J6gICiFBCFpjlFNF+HFfhm\nUI36rPZ/1was5IsFhru0k3NBfUgrqrHd6Qv3c11nAoGAbgwDLdtJJL03xySzgF6h\nqGFkEtkqZCKh4BJ8LUM0bjRqpJ5UQphJqjmaWjn7fCZ5OOds9MyV9l29RnmuIz3G\n+mNyhgK2PpLFssqCJjne40Jsa/ppYky8Xv8sZrcZ8tkMMIkCgFW/vGsrMoDZzmxg\nDRb2Ns1o7owaJzUkJcdazDc=\n-----END PRIVATE KEY-----",
+    "account_management_url": "https://home.account.gov.uk",
+    "client_id": "local-rp-stub",
+    "client_type": "web",
+    "id_token_signing_algorithm": "ES256",
+    "service_name": "Local RP Stub",
+    "op_base_url": "http://host.docker.internal:4400/",
+    "token_client_secret": "local-client-secret"
+  }
+}

--- a/config.local.json
+++ b/config.local.json
@@ -8,6 +8,6 @@
     "id_token_signing_algorithm": "ES256",
     "service_name": "Local RP Stub",
     "op_base_url": "http://host.docker.internal:4400/",
-    "token_client_secret": "local-client-secret"
+    "token_client_secret": null
   }
 }

--- a/src/main/java/uk/gov/di/OidcRp.java
+++ b/src/main/java/uk/gov/di/OidcRp.java
@@ -25,9 +25,11 @@ import static spark.Spark.staticFileLocation;
 import static uk.gov.di.config.Configuration.getClientsPublicKeys;
 
 public class OidcRp {
+    private static final int DEFAULT_PORT = 8080;
+
     public OidcRp() {
         staticFileLocation("/public");
-        port(8080);
+        port(getPort());
 
         initRoutes();
     }
@@ -74,5 +76,10 @@ public class OidcRp {
         internalServerError(internalServerErrorHandler);
 
         after("/*", (req, res) -> ResponseHeaderHelper.setHeaders(res));
+    }
+
+    private int getPort() {
+        var envPort = System.getenv("PORT");
+        return envPort == null ? DEFAULT_PORT : Integer.parseInt(envPort);
     }
 }

--- a/src/main/java/uk/gov/di/handlers/SignOutHandler.java
+++ b/src/main/java/uk/gov/di/handlers/SignOutHandler.java
@@ -20,12 +20,14 @@ public class SignOutHandler implements Route {
         var relyingPartyConfig =
                 Configuration.getRelyingPartyConfig(request.cookie("relyingParty"));
         var oidcClient = new Oidc(relyingPartyConfig);
+        var useAlternativeDomain = "true".equals(request.cookie("useAlternativeDomain"));
 
         var logoutUri =
                 oidcClient.buildLogoutUrl(
                         request.cookie("idToken"),
                         UUID.randomUUID().toString(),
-                        relyingPartyConfig.postLogoutRedirectUrl());
+                        relyingPartyConfig.postLogoutRedirectUrl(),
+                        useAlternativeDomain);
         response.redirect(logoutUri);
         return null;
     }

--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -74,15 +74,13 @@ public class Oidc {
 
     private final OIDCProviderMetadata providerMetadata;
     private final Optional<OIDCProviderMetadata> alternativeProviderMetadata;
-    private final String idpUrl;
     private final ClientID clientId;
     private final PrivateKeyReader privateKeyReader;
 
     public Oidc(RPConfig relyingPartyConfig) {
         this.relyingPartyConfig = relyingPartyConfig;
-        this.idpUrl = relyingPartyConfig.opBaseUrl();
         this.clientId = new ClientID(relyingPartyConfig.clientId());
-        this.providerMetadata = loadProviderMetadata(idpUrl);
+        this.providerMetadata = loadProviderMetadata(relyingPartyConfig.opBaseUrl());
         this.alternativeProviderMetadata =
                 Optional.ofNullable(relyingPartyConfig.alternativeBaseUrl())
                         .map(this::loadProviderMetadata);
@@ -366,10 +364,15 @@ public class Oidc {
         return authRequestBuilder.build().toURI().toString();
     }
 
-    public String buildLogoutUrl(String idToken, String state, String postLogoutRedirectUri)
+    public String buildLogoutUrl(
+            String idToken,
+            String state,
+            String postLogoutRedirectUri,
+            boolean useAlternativeDomain)
             throws URISyntaxException {
         var logoutUri =
-                new URIBuilder(this.idpUrl + (this.idpUrl.endsWith("/") ? "logout" : "/logout"));
+                new URIBuilder(
+                        getProviderMetadata(useAlternativeDomain).getEndSessionEndpointURI());
         logoutUri.addParameter("id_token_hint", idToken);
         logoutUri.addParameter("state", state);
         logoutUri.addParameter("post_logout_redirect_uri", postLogoutRedirectUri);


### PR DESCRIPTION
## What?

Updates for running the relying party stub as part of a fully local Orchestration environment:

- Local configuration files, including a local-only keypair
- Update to use the logout URL from the OIDC metadata
- Pin the Dockerfile image shas

## Why?

We would like to be able to run Orchestration locally, and a local RP stub is required to test the journey by hand.

## Related PRs

- Orchestration API: https://github.com/govuk-one-login/authentication-api/pull/8221
- Orch stubs: https://github.com/govuk-one-login/orch-stubs/pull/543
